### PR TITLE
Refactoring + Overloads For init & StartAs*

### DIFF
--- a/src/DW1000.cpp
+++ b/src/DW1000.cpp
@@ -18,7 +18,6 @@
  * Arduino driver library (source file) for the Decawave DW1000 UWB transceiver IC.
  */
 
-#include "digitalWriteFast.h"
 #include "pins_arduino.h"
 #include "DW1000.h"
 
@@ -1493,7 +1492,7 @@ void DW1000Class::readBytes(byte cmd, word offset, byte data[], unsigned int n) 
 		}
 	}
 	SPI.beginTransaction(*_currentSPI);
-	digitalWriteFast(_ss, LOW);
+	digitalWrite(_ss, LOW);
 	for(i = 0; i < headerLen; i++) {
 		SPI.transfer(header[i]);
 	}
@@ -1501,7 +1500,7 @@ void DW1000Class::readBytes(byte cmd, word offset, byte data[], unsigned int n) 
 		data[i] = SPI.transfer(JUNK);
 	}
 	delayMicroseconds(5);
-	digitalWriteFast(_ss,HIGH);
+	digitalWrite(_ss,HIGH);
 	SPI.endTransaction();
 }
 
@@ -1557,7 +1556,7 @@ void DW1000Class::writeBytes(byte cmd, word offset, byte data[], unsigned int n)
 		}
 	}
 	SPI.beginTransaction(*_currentSPI); 
-	digitalWriteFast(_ss, LOW);
+	digitalWrite(_ss, LOW);
 	for(i = 0; i < headerLen; i++) {
 		SPI.transfer(header[i]);
 	}
@@ -1565,7 +1564,7 @@ void DW1000Class::writeBytes(byte cmd, word offset, byte data[], unsigned int n)
 		SPI.transfer(data[i]);
 	}
 	delayMicroseconds(5);
-	digitalWriteFast(_ss,HIGH);
+	digitalWrite(_ss,HIGH);
 	SPI.endTransaction();
 }
 

--- a/src/DW1000Ranging.h
+++ b/src/DW1000Ranging.h
@@ -41,6 +41,7 @@
 //Default Pin for module:
 #define DEFAULT_RST_PIN 9
 #define DEFAULT_SPI_SS_PIN 10
+#define DEFAULT_INT 0
 
 //Default value
 //in ms
@@ -55,6 +56,9 @@
 //default timer delay
 #define DEFAULT_TIMER_DELAY 80
  
+//default Network Id
+#define DEFAULT_NETWORK_Id 0xDECA
+
 
 //debug mode
 #ifndef DEBUG
@@ -70,13 +74,18 @@ class DW1000RangingClass {
     
     
     //initialisation
-    static void initCommunication(unsigned int myRST=DEFAULT_RST_PIN, unsigned int mySS=DEFAULT_SPI_SS_PIN);
+	static void initCommunication(unsigned int myRST, unsigned int mySS);
+    static void initCommunication(unsigned int myRST=DEFAULT_RST_PIN, unsigned int mySS=DEFAULT_SPI_SS_PIN, unsigned int myINT=DEFAULT_INT);
     static void configureNetwork(unsigned int deviceAddress, unsigned int networkId, const byte mode[]); 
-    static void generalStart();
+    static void generalStart(char address[], const byte mode[],byte familyId, byte nodeId,unsigned int networkId,byte type);
     static void startAsAnchor(char address[], const byte mode[]);
-    static void startAsTag(char address[], const byte mode[]);
-    static boolean addNetworkDevices(DW1000Device *device, boolean shortAddress);
-    static boolean addNetworkDevices(DW1000Device *device);
+	static void startAsAnchor(char address[],const byte mode[], byte familyId, byte nodeId);
+	static void startAsAnchor(char address[],const byte mode[], byte familyId, byte nodeId, unsigned int networkId);
+	static void startAsTag(char address[], const byte mode[]);
+	static void startAsTag(char address[],const byte mode[], byte familyId, byte nodeId);
+	static void startAsTag(char address[],const byte mode[], byte familyId, byte nodeId, unsigned int networkId);
+          
+    static boolean addNetworkDevices(DW1000Device *device, boolean shortAddress=false);
     static void removeNetworkDevices(short index);
     
     //setters
@@ -87,6 +96,7 @@ class DW1000RangingClass {
     static byte* getCurrentAddress(){return _currentAddress; };
     static byte* getCurrentShortAddress(){return _currentShortAddress; };
     static short getNetworkDevicesNumber(){return _networkDevicesNumber; };
+	static byte* generateShortAddress();
     
     //ranging functions
     static short detectMessageType(byte datas[]);


### PR DESCRIPTION
- Added Overload For initCommunication To Allow Passing In Interrupt
(Note: This is the actual interrupt, not the physical pin)
- Added Overloads For StartAsAnchor & StartAsTag To Allow Passing In
FamilyID, NodeID, and NetworkID
- Refactored StartAsAnchor & StartAsTag To Accomodate Overloads
- Refactored & Consolidated Overloads For AddNewworkDevices
- Removed Excessive Whitespace And Formatted