### PR TITLE
Changed all message buffers in example code to 128 bytes. This is the…

### DIFF
--- a/examples/BasicConnectivityTest/BasicConnectivityTest.ino
+++ b/examples/BasicConnectivityTest/BasicConnectivityTest.ino
@@ -44,7 +44,7 @@ void loop() {
   // wait a bit
   delay(1000);
   // DEBUG chip info and registers pretty printed
-  char msg[64];
+  char msg[128];
   DW1000.getPrintableDeviceIdentifier(msg);
   Serial.print("Device ID: "); Serial.println(msg);
   DW1000.getPrintableExtendedUniqueIdentifier(msg);

--- a/examples/BasicReceiver/BasicReceiver.ino
+++ b/examples/BasicReceiver/BasicReceiver.ino
@@ -47,7 +47,7 @@ void setup() {
   DW1000.commitConfiguration();
   Serial.println("Committed configuration ...");
   // DEBUG chip info and registers pretty printed
-  char msg[1024];
+  char msg[128];
   DW1000.getPrintableDeviceIdentifier(msg);
   Serial.print("Device ID: "); Serial.println(msg);
   DW1000.getPrintableExtendedUniqueIdentifier(msg);

--- a/examples/BasicSender/BasicSender.ino
+++ b/examples/BasicSender/BasicSender.ino
@@ -48,7 +48,7 @@ void setup() {
   DW1000.commitConfiguration();
   Serial.println("Committed configuration ...");
   // DEBUG chip info and registers pretty printed
-  char msg[1024];
+  char msg[128];
   DW1000.getPrintableDeviceIdentifier(msg);
   Serial.print("Device ID: "); Serial.println(msg);
   DW1000.getPrintableExtendedUniqueIdentifier(msg);

--- a/examples/MessagePingPong/MessagePingPong.ino
+++ b/examples/MessagePingPong/MessagePingPong.ino
@@ -56,7 +56,7 @@ void setup() {
   DW1000.commitConfiguration();
   Serial.println("Committed configuration ...");
   // DEBUG chip info and registers pretty printed
-  char msgInfo[1024];
+  char msgInfo[128];
   DW1000.getPrintableDeviceIdentifier(msgInfo);
   Serial.print("Device ID: "); Serial.println(msgInfo);
   DW1000.getPrintableExtendedUniqueIdentifier(msgInfo);

--- a/examples/RangingTag/RangingTag.ino
+++ b/examples/RangingTag/RangingTag.ino
@@ -69,7 +69,7 @@ void setup() {
     DW1000.commitConfiguration();
     Serial.println("Committed configuration ...");
     // DEBUG chip info and registers pretty printed
-    char msg[256];
+    char msg[128];
     DW1000.getPrintableDeviceIdentifier(msg);
     Serial.print("Device ID: "); Serial.println(msg);
     DW1000.getPrintableExtendedUniqueIdentifier(msg);


### PR DESCRIPTION
… largest value needed for function returns. Now consistent across example files.