### PR TITLE
fix digitalWriteFast only for AVR and some more changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ datasheets
 # exclude IDE stuff
 .idea
 cmake
+CMakeLists.txt

--- a/examples/DW1000Ranging_ANCHOR/DW1000Ranging_ANCHOR.ino
+++ b/examples/DW1000Ranging_ANCHOR/DW1000Ranging_ANCHOR.ino
@@ -5,15 +5,14 @@
 
 // connection pins
 const uint8_t PIN_RST = 9; // reset pin
+const uint8_t PIN_IRQ = 2; // irq pin
 const uint8_t PIN_SS = SS; // spi select pin
-// not used:
-//const uint8_t PIN_IRQ = 2; // irq pin
 
 void setup() {
   Serial.begin(115200);
   delay(1000);
   //init the configuration
-  DW1000Ranging.initCommunication(PIN_RST, PIN_SS); //Reset and CS pin  
+  DW1000Ranging.initCommunication(PIN_RST, PIN_SS, PIN_IRQ); //Reset, CS, IRQ pin
   //define the sketch as anchor. It will be great to dynamically change the type of module
   DW1000Ranging.attachNewRange(newRange);
   //we start the module as an anchor

--- a/examples/DW1000Ranging_TAG/DW1000Ranging_TAG.ino
+++ b/examples/DW1000Ranging_TAG/DW1000Ranging_TAG.ino
@@ -5,15 +5,14 @@
 
 // connection pins
 const uint8_t PIN_RST = 9; // reset pin
+const uint8_t PIN_IRQ = 2; // irq pin
 const uint8_t PIN_SS = SS; // spi select pin
-// not used:
-//const uint8_t PIN_IRQ = 2; // irq pin
 
 void setup() {
   Serial.begin(115200);
   delay(1000);
   //init the configuration
-  DW1000Ranging.initCommunication(PIN_RST, PIN_SS); //Reset and CS pin  
+  DW1000Ranging.initCommunication(PIN_RST, PIN_SS, PIN_IRQ); //Reset, CS, IRQ pin
   //define the sketch as anchor. It will be great to dynamically change the type of module
   DW1000Ranging.attachNewRange(newRange);
   //we start the module as a tag

--- a/examples/RangingTag/RangingTag.ino
+++ b/examples/RangingTag/RangingTag.ino
@@ -60,7 +60,7 @@ void setup() {
     Serial.begin(115200);
     Serial.println(F("### DW1000-arduino-ranging-tag ###"));
     // initialize the driver
-    DW1000.begin(PIN_RST, PIN_RST);
+    DW1000.begin(PIN_IRQ, PIN_RST);
     DW1000.select(PIN_SS);
     Serial.println("DW1000 initialized ...");
     // general configuration

--- a/src/DW1000.cpp
+++ b/src/DW1000.cpp
@@ -18,7 +18,9 @@
  * Arduino driver library (source file) for the Decawave DW1000 UWB transceiver IC.
  */
 
+#ifdef __AVR__
 #include "digitalWriteFast.h"
+#endif
 #include "pins_arduino.h"
 #include "DW1000.h"
 
@@ -1496,7 +1498,11 @@ void DW1000Class::readBytes(byte cmd, word offset, byte data[], unsigned int n) 
 		}
 	}
 	SPI.beginTransaction(*_currentSPI);
+#ifdef __AVR__
 	digitalWriteFast(_ss, LOW);
+#else
+	digitalWrite(_ss, LOW);
+#endif
 	for(i = 0; i < headerLen; i++) {
 		SPI.transfer(header[i]);
 	}
@@ -1504,7 +1510,11 @@ void DW1000Class::readBytes(byte cmd, word offset, byte data[], unsigned int n) 
 		data[i] = SPI.transfer(JUNK);
 	}
 	delayMicroseconds(5);
+#ifdef __AVR__
 	digitalWriteFast(_ss, HIGH);
+#else
+	digitalWrite(_ss, HIGH);
+#endif
 	SPI.endTransaction();
 }
 
@@ -1560,7 +1570,11 @@ void DW1000Class::writeBytes(byte cmd, word offset, byte data[], unsigned int n)
 		}
 	}
 	SPI.beginTransaction(*_currentSPI);
+#ifdef __AVR__
 	digitalWriteFast(_ss, LOW);
+#else
+	digitalWrite(_ss, LOW);
+#endif
 	for(i = 0; i < headerLen; i++) {
 		SPI.transfer(header[i]);
 	}
@@ -1568,7 +1582,11 @@ void DW1000Class::writeBytes(byte cmd, word offset, byte data[], unsigned int n)
 		SPI.transfer(data[i]);
 	}
 	delayMicroseconds(5);
+#ifdef __AVR__
 	digitalWriteFast(_ss, HIGH);
+#else
+	digitalWrite(_ss, HIGH);
+#endif
 	SPI.endTransaction();
 }
 

--- a/src/DW1000.cpp
+++ b/src/DW1000.cpp
@@ -1097,6 +1097,8 @@ void DW1000Class::setDefaults() {
 		useSmartPower(false);
 		suppressFrameCheck(false);
 		//for global frame filtering
+		setFrameFilter(false);
+		/* old defaults with active frame filter - better set filter in every script where you really need it
 		setFrameFilter(true);
 		//for data frame (poll, poll_ack, range, range report, range failed) filtering
 		setFrameFilterAllowData(true);
@@ -1105,6 +1107,7 @@ void DW1000Class::setDefaults() {
 		//setFrameFilterAllowMAC(true);
 		//setFrameFilterAllowBeacon(true);
 		//setFrameFilterAllowAcknowledgement(true);
+		*/
 		interruptOnSent(true);
 		interruptOnReceived(true);
 		interruptOnReceiveFailed(true);

--- a/src/DW1000.cpp
+++ b/src/DW1000.cpp
@@ -101,8 +101,8 @@ void DW1000Class::select(int ss) {
 	delay(5);
 	// reset chip (either soft or hard)
 	if(_rst > 0) {
-		pinMode(_rst, OUTPUT);
-		digitalWrite(_rst, HIGH);
+		// sheet §5.6.1 page 20, the RSTn pin should not be driven high but left floating.
+		pinMode(_rst, INPUT);
 	}
 	reset();
 	// default network and node id
@@ -204,10 +204,12 @@ void DW1000Class::reset() {
 	if(_rst < 0) {
 		softReset();
 	} else {
+		// sheet §5.6.1 page 20, the RSTn pin should not be driven high but left floating.
+		pinMode(_rst, OUTPUT);
 		digitalWrite(_rst, LOW);
-		delay(10);
-		digitalWrite(_rst, HIGH);
-		delay(10);
+		delay(10); // TODO verify time
+		pinMode(_rst, INPUT);
+		delay(10); // TODO verify time
 		// force into idle mode (although it should be already after reset)
 		idle();
 	}

--- a/src/DW1000.cpp
+++ b/src/DW1000.cpp
@@ -101,7 +101,7 @@ void DW1000Class::select(int ss) {
 	delay(5);
 	// reset chip (either soft or hard)
 	if(_rst > 0) {
-		// sheet §5.6.1 page 20, the RSTn pin should not be driven high but left floating.
+		// dw1000 data sheet v2.08 §5.6.1 page 20, the RSTn pin should not be driven high but left floating.
 		pinMode(_rst, INPUT);
 	}
 	reset();
@@ -204,12 +204,12 @@ void DW1000Class::reset() {
 	if(_rst < 0) {
 		softReset();
 	} else {
-		// sheet §5.6.1 page 20, the RSTn pin should not be driven high but left floating.
+		// dw1000 data sheet v2.08 §5.6.1 page 20, the RSTn pin should not be driven high but left floating.
 		pinMode(_rst, OUTPUT);
 		digitalWrite(_rst, LOW);
-		delay(10); // TODO verify time
+		delay(2);  // dw1000 data sheet v2.08 §5.6.1 page 20: nominal 50ns, to be safe take more time
 		pinMode(_rst, INPUT);
-		delay(10); // TODO verify time
+		delay(10); // dwm1000 data sheet v1.2 page 5: nominal 3 ms, to be safe take more time
 		// force into idle mode (although it should be already after reset)
 		idle();
 	}

--- a/src/DW1000.h
+++ b/src/DW1000.h
@@ -661,7 +661,8 @@ private:
 	
 	/* Arduino interrupt handler */
 	static void handleInterrupt();
-	
+
+public: // TODO move and resort functions - filter functions should be accessible from external
 	/* Allow MAC frame filtering . */
 	// TODO auto-acknowledge
 	static void setFrameFilter(boolean val);
@@ -673,7 +674,8 @@ private:
 	static void setFrameFilterAllowMAC(boolean val);
 	//Reserved is used for the Blink message
 	static void setFrameFilterAllowReserved(boolean val);
-	
+
+private:
 	// note: not sure if going to be implemented for now
 	static void setDoubleBuffering(boolean val);
 	// TODO is implemented, but needs testing

--- a/src/DW1000Ranging.cpp
+++ b/src/DW1000Ranging.cpp
@@ -76,7 +76,7 @@ void (* DW1000RangingClass::_handleNewRange)(void) = 0;
  * #### Init and end #######################################################
  * ######################################################################### */
 
-void DW1000RangingClass::initCommunication(unsigned int myRST, unsigned int mySS) {
+void DW1000RangingClass::initCommunication(uint8_t myRST, uint8_t mySS, uint8_t myIRQ) {
 	// reset line to the chip
 	_RST              = myRST;
 	_SS               = mySS;
@@ -87,7 +87,7 @@ void DW1000RangingClass::initCommunication(unsigned int myRST, unsigned int mySS
 	_timerDelay       = DEFAULT_TIMER_DELAY;
 	
 	
-	DW1000.begin(0, myRST);
+	DW1000.begin(myIRQ, myRST);
 	DW1000.select(mySS);
 }
 

--- a/src/DW1000Ranging.h
+++ b/src/DW1000Ranging.h
@@ -70,7 +70,7 @@ public:
 	
 	
 	//initialisation
-	static void    initCommunication(unsigned int myRST = DEFAULT_RST_PIN, unsigned int mySS = DEFAULT_SPI_SS_PIN);
+	static void    initCommunication(uint8_t myRST = DEFAULT_RST_PIN, uint8_t mySS = DEFAULT_SPI_SS_PIN, uint8_t myIRQ = 2);
 	static void    configureNetwork(unsigned int deviceAddress, unsigned int networkId, const byte mode[]);
 	static void    generalStart();
 	static void    startAsAnchor(char address[], const byte mode[]);


### PR DESCRIPTION
fixes #84 #40 
digitalWriteFast only supports avr
no need of manual change any more, pre compiler does it

Important note: impact in timing and accuracy on other systems than avr has to be tested and evaluated and may vary highly 