### PR TITLE
Added distance filter for DW1000Ranging (TAG and ANCHOR)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ datasheets
 .idea
 cmake
 CMakeLists.txt
+#exclude OSX stuff
+.DS_STORE

--- a/src/DW1000Ranging.cpp
+++ b/src/DW1000Ranging.cpp
@@ -559,14 +559,14 @@ void DW1000RangingClass::loop() {
 								computeRangeAsymmetric(myDistantDevice, &myTOF); // CHOSEN RANGING ALGORITHM
 								
 								float distance = myTOF.getAsMeters();
-                                
-                                if (_useRangeFilter) {
-                                    //Skip first range
-                                    if (myDistantDevice->getRange() != 0.0f) {
-                                        distance = filterValue(distance, myDistantDevice->getRange(), RANGE_FILTER_VALUE);
-                                    }
-                                }
-                                
+								
+								if (_useRangeFilter) {
+									//Skip first range
+									if (myDistantDevice->getRange() != 0.0f) {
+										distance = filterValue(distance, myDistantDevice->getRange(), RANGE_FILTER_VALUE);
+									}
+								}
+								
 								myDistantDevice->setRXPower(DW1000.getReceivePower());
 								myDistantDevice->setRange(distance);
 								
@@ -626,14 +626,14 @@ void DW1000RangingClass::loop() {
 					memcpy(&curRange, data+1+SHORT_MAC_LEN, 4);
 					float curRXPower;
 					memcpy(&curRXPower, data+5+SHORT_MAC_LEN, 4);
-                    
-                    if (_useRangeFilter) {
-                        //Skip first range
-                        if (myDistantDevice->getRange() != 0.0f) {
-                            curRange = filterValue(curRange, myDistantDevice->getRange(), RANGE_FILTER_VALUE);
-                        }
-                    }
-                    //Serial.print("Current:");Serial.print(myDistantDevice->getRange());Serial.print(" New:");Serial.println(curRange);
+					
+					if (_useRangeFilter) {
+						//Skip first range
+						if (myDistantDevice->getRange() != 0.0f) {
+							curRange = filterValue(curRange, myDistantDevice->getRange(), RANGE_FILTER_VALUE);
+						}
+					}
+					//Serial.print("Current:");Serial.print(myDistantDevice->getRange());Serial.print(" New:");Serial.println(curRange);
 					//we have a new range to save !
 					myDistantDevice->setRange(curRange);
 					myDistantDevice->setRXPower(curRXPower);
@@ -658,7 +658,7 @@ void DW1000RangingClass::loop() {
 }
 
 void DW1000RangingClass::useRangeFilter(boolean enabled) {
-    _useRangeFilter = enabled;
+	_useRangeFilter = enabled;
 }
 
 
@@ -958,9 +958,9 @@ void DW1000RangingClass::visualizeDatas(byte datas[]) {
 //Utils
 
 float DW1000RangingClass::filterValue(float value, float previousValue, int numberOfElements) {
-    
-    float k = 2.0f / ((float)numberOfElements + 1.0f);
-    return (value * k) + previousValue * (1.0f - k);
+	
+	float k = 2.0f / ((float)numberOfElements + 1.0f);
+	return (value * k) + previousValue * (1.0f - k);
 }
 
 

--- a/src/DW1000Ranging.h
+++ b/src/DW1000Ranging.h
@@ -55,7 +55,8 @@
 //default timer delay
 #define DEFAULT_TIMER_DELAY 80
 
-
+//Range filter value
+#define RANGE_FILTER_VALUE 15
 //debug mode
 #ifndef DEBUG
 #define DEBUG false
@@ -93,6 +94,7 @@ public:
 	//ranging functions
 	static short detectMessageType(byte datas[]);
 	static void  loop();
+    static void useRangeFilter(boolean enabled);
 	
 	
 	//Handlers:
@@ -143,7 +145,8 @@ private:
 	// ranging counter (per second)
 	static unsigned int     _successRangingCount;
 	static unsigned long    _rangingCountPeriod;
-	
+	//ranging filter
+    static volatile boolean _useRangeFilter;
 	//_bias correction
 	static char  _bias_RSL[17];
 	//17*2=34 bytes in SRAM
@@ -183,6 +186,8 @@ private:
 	
 	static void timerTick();
 	
+    //Utils
+    static float filterValue(float value, float previousValue, int numberOfElements);
 };
 
 extern DW1000RangingClass DW1000Ranging;

--- a/src/DW1000Ranging.h
+++ b/src/DW1000Ranging.h
@@ -94,7 +94,7 @@ public:
 	//ranging functions
 	static short detectMessageType(byte datas[]);
 	static void  loop();
-    static void useRangeFilter(boolean enabled);
+	static void useRangeFilter(boolean enabled);
 	
 	
 	//Handlers:
@@ -146,7 +146,7 @@ private:
 	static unsigned int     _successRangingCount;
 	static unsigned long    _rangingCountPeriod;
 	//ranging filter
-    static volatile boolean _useRangeFilter;
+	static volatile boolean _useRangeFilter;
 	//_bias correction
 	static char  _bias_RSL[17];
 	//17*2=34 bytes in SRAM
@@ -186,8 +186,8 @@ private:
 	
 	static void timerTick();
 	
-    //Utils
-    static float filterValue(float value, float previousValue, int numberOfElements);
+	//Utils
+	static float filterValue(float value, float previousValue, int numberOfElements);
 };
 
 extern DW1000RangingClass DW1000Ranging;


### PR DESCRIPTION
Just my 2 cents.
I don't know from your side but here using the TAG-ANCHOR project the ranges (distances) are very noisy (30-60 cm).
So i wrote a small fix using the [Exponential Moving Average](https://en.wikipedia.org/wiki/Moving_average#Exponential_moving_average).

It can be enabled or disabled on the fly using the method:
`DW1000Ranging.useRangeFilter(true)`

Right now the smoothing factor is a constant `RANGE_FILTER_VALUE`, let me know what you think about if it's a good idea or a stupid one.

Bye, Pascal.