### PR TITLE
Added customizable range filter value

### DIFF
--- a/src/DW1000Ranging.cpp
+++ b/src/DW1000Ranging.cpp
@@ -47,6 +47,7 @@ volatile boolean DW1000RangingClass::_receivedAck = false;
 
 // range filter
 volatile boolean DW1000RangingClass::_useRangeFilter = false;
+unsigned int DW1000RangingClass::_rangeFilterValue = 15;
 
 // protocol error state
 boolean          DW1000RangingClass::_protocolFailed = false;
@@ -563,7 +564,7 @@ void DW1000RangingClass::loop() {
 								if (_useRangeFilter) {
 									//Skip first range
 									if (myDistantDevice->getRange() != 0.0f) {
-										distance = filterValue(distance, myDistantDevice->getRange(), RANGE_FILTER_VALUE);
+										distance = filterValue(distance, myDistantDevice->getRange(), _rangeFilterValue);
 									}
 								}
 								
@@ -610,9 +611,6 @@ void DW1000RangingClass::loop() {
 					//we note activity for our device:
 					myDistantDevice->noteActivity();
 					
-					
-					
-					
 					//in the case the message come from our last device:
 					if(myDistantDevice->getIndex() == _networkDevicesNumber-1) {
 						_expectedMsgId = RANGE_REPORT;
@@ -630,10 +628,10 @@ void DW1000RangingClass::loop() {
 					if (_useRangeFilter) {
 						//Skip first range
 						if (myDistantDevice->getRange() != 0.0f) {
-							curRange = filterValue(curRange, myDistantDevice->getRange(), RANGE_FILTER_VALUE);
+							curRange = filterValue(curRange, myDistantDevice->getRange(), _rangeFilterValue);
 						}
 					}
-					//Serial.print("Current:");Serial.print(myDistantDevice->getRange());Serial.print(" New:");Serial.println(curRange);
+
 					//we have a new range to save !
 					myDistantDevice->setRange(curRange);
 					myDistantDevice->setRXPower(curRXPower);
@@ -659,6 +657,14 @@ void DW1000RangingClass::loop() {
 
 void DW1000RangingClass::useRangeFilter(boolean enabled) {
 	_useRangeFilter = enabled;
+}
+
+void DW1000RangingClass::setRangeFilterValue(unsigned int newValue) {
+	if (newValue < 2) {
+		_rangeFilterValue = 2;
+	}else{
+		_rangeFilterValue = newValue;
+	}
 }
 
 

--- a/src/DW1000Ranging.h
+++ b/src/DW1000Ranging.h
@@ -55,8 +55,6 @@
 //default timer delay
 #define DEFAULT_TIMER_DELAY 80
 
-//Range filter value
-#define RANGE_FILTER_VALUE 15
 //debug mode
 #ifndef DEBUG
 #define DEBUG false
@@ -95,7 +93,8 @@ public:
 	static short detectMessageType(byte datas[]);
 	static void  loop();
 	static void useRangeFilter(boolean enabled);
-	
+	// Used for the smoothing algorithm (Exponential Moving Average). newValue must be >= 2. Default 15.
+	static void setRangeFilterValue(unsigned int newValue);
 	
 	//Handlers:
 	static void attachNewRange(void (* handleNewRange)(void)) { _handleNewRange = handleNewRange; };
@@ -147,6 +146,7 @@ private:
 	static unsigned long    _rangingCountPeriod;
 	//ranging filter
 	static volatile boolean _useRangeFilter;
+	static unsigned int _rangeFilterValue;
 	//_bias correction
 	static char  _bias_RSL[17];
 	//17*2=34 bytes in SRAM


### PR DESCRIPTION
Just a small fix, now is possible to customize the filter value. (See https://github.com/thotro/arduino-dw1000/commit/465328c8e7e272fbccc10491654f97306bdb0201)

    DW1000Ranging.useRangeFilter(true);
    DW1000Ranging.setRangeFilterValue(15);

The minimum value is 2 (2 cycles to reach the updated value)
There's no maximum but a nice value can be 10...30 depends on the requirements.
Keep in mind greater is the value, less responsive are the measurements. Default value 15.