### PR TITLE
Added handlers on blink (ANCHOR), range init (TAG) and inactive (ANCH…

### DIFF
--- a/examples/DW1000Ranging_ANCHOR/DW1000Ranging_ANCHOR.ino
+++ b/examples/DW1000Ranging_ANCHOR/DW1000Ranging_ANCHOR.ino
@@ -15,6 +15,11 @@ void setup() {
   DW1000Ranging.initCommunication(PIN_RST, PIN_SS, PIN_IRQ); //Reset, CS, IRQ pin
   //define the sketch as anchor. It will be great to dynamically change the type of module
   DW1000Ranging.attachNewRange(newRange);
+  DW1000Ranging.attachBlinkDevice(newBlink);
+  DW1000Ranging.attachInactiveDevice(inactiveDevice);
+  //Enable the filter to smooth the distance
+  //DW1000Ranging.useRangeFilter(true);
+  
   //we start the module as an anchor
   DW1000Ranging.startAsAnchor("82:17:5B:D5:A9:9A:E2:9C", DW1000.MODE_LONGDATA_RANGE_ACCURACY);
 }
@@ -27,5 +32,16 @@ void newRange() {
   Serial.print("from: "); Serial.print(DW1000Ranging.getDistantDevice()->getShortAddress(), HEX);
   Serial.print("\t Range: "); Serial.print(DW1000Ranging.getDistantDevice()->getRange()); Serial.print(" m");
   Serial.print("\t RX power: "); Serial.print(DW1000Ranging.getDistantDevice()->getRXPower()); Serial.println(" dBm");
+}
+
+void newBlink(DW1000Device* device) {
+  Serial.print("blink; 1 device added ! -> ");
+  Serial.print(" short:");
+  Serial.println(device->getShortAddress(), HEX);
+}
+
+void inactiveDevice(DW1000Device* device) {
+  Serial.print("delete inactive device: ");
+  Serial.println(device->getShortAddress(), HEX);
 }
 

--- a/examples/DW1000Ranging_TAG/DW1000Ranging_TAG.ino
+++ b/examples/DW1000Ranging_TAG/DW1000Ranging_TAG.ino
@@ -15,6 +15,11 @@ void setup() {
   DW1000Ranging.initCommunication(PIN_RST, PIN_SS, PIN_IRQ); //Reset, CS, IRQ pin
   //define the sketch as anchor. It will be great to dynamically change the type of module
   DW1000Ranging.attachNewRange(newRange);
+  DW1000Ranging.attachNewDevice(newDevice);
+  DW1000Ranging.attachInactiveDevice(inactiveDevice);
+  //Enable the filter to smooth the distance
+  //DW1000Ranging.useRangeFilter(true);
+  
   //we start the module as a tag
   DW1000Ranging.startAsTag("7D:00:22:EA:82:60:3B:9C", DW1000.MODE_LONGDATA_RANGE_ACCURACY);
 }
@@ -27,5 +32,16 @@ void newRange() {
   Serial.print("from: "); Serial.print(DW1000Ranging.getDistantDevice()->getShortAddress(), HEX);
   Serial.print("\t Range: "); Serial.print(DW1000Ranging.getDistantDevice()->getRange()); Serial.print(" m");
   Serial.print("\t RX power: "); Serial.print(DW1000Ranging.getDistantDevice()->getRXPower()); Serial.println(" dBm");
+}
+
+void newDevice(DW1000Device* device) {
+  Serial.print("ranging init; 1 device added ! -> ");
+  Serial.print(" short:");
+  Serial.println(device->getShortAddress(), HEX);
+}
+
+void inactiveDevice(DW1000Device* device) {
+  Serial.print("delete inactive device: ");
+  Serial.println(device->getShortAddress(), HEX);
 }
 

--- a/src/DW1000Ranging.h
+++ b/src/DW1000Ranging.h
@@ -99,6 +99,13 @@ public:
 	//Handlers:
 	static void attachNewRange(void (* handleNewRange)(void)) { _handleNewRange = handleNewRange; };
 	
+	static void attachBlinkDevice(void (* handleBlinkDevice)(DW1000Device*)) { _handleBlinkDevice = handleBlinkDevice; };
+	
+	static void attachNewDevice(void (* handleNewDevice)(DW1000Device*)) { _handleNewDevice = handleNewDevice; };
+	
+	static void attachInactiveDevice(void (* handleInactiveDevice)(DW1000Device*)) { _handleInactiveDevice = handleInactiveDevice; };
+	
+	
 	
 	static DW1000Device* getDistantDevice();
 	static DW1000Device* searchDistantDevice(byte shortAddress[]);
@@ -121,6 +128,9 @@ private:
 	
 	//Handlers:
 	static void (* _handleNewRange)(void);
+	static void (* _handleBlinkDevice)(DW1000Device*);
+	static void (* _handleNewDevice)(DW1000Device*);
+	static void (* _handleInactiveDevice)(DW1000Device*);
 	
 	//sketch type (tag or anchor)
 	static int              _type; //0 for tag and 1 for anchor


### PR DESCRIPTION
Hi,
Just noticed there isn't a way to be notified when an anchor receive a blink (new tag added), a tag add an anchor and a tag or an anchor has been removed.
I think this can be very useful if the tag (or anchor) wants to be notified if something happens in the network from its "perspective".

For example, in my case I want to keep a list of devices (distances) and recalculate my position not only when a new range happens but also when an existing anchor disappears or a new one appears.

I also moved the logs to the sketches.
Please, find below the new functions:

    static void attachBlinkDevice(void (* handleBlinkDevice)(DW1000Device*));
    static void attachNewDevice(void (* handleNewDevice)(DW1000Device*));
    static void attachInactiveDevice(void (* handleInactiveDevice)(DW1000Device*));

Let me know if it can help or is useless.

Bye, Pascal. ;)