### PR TITLE
refactored DW1000Time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,10 @@
+notifications:
+  email:
+    recipients:
+      - secure: "axZN6doTif7sLXc0h72F8dC2HHoep647SxzLFpIg/ACVXKALNB2o5ZS/oELs1/fQq+wZLvpaOOtsVMhbbinfm/J438v3EQieUSQ3+YKQB8jpYPTvIvCMgjorgwmfFWQiVwtHTIodI2zpPKA2oVCQjC0n08u/jpb2yIwEQsLcfMCnOlvWO4vVuTVLydAUtvC5P7md/OLEsKKIIUvd2zfB/vOx44Kpv45GD2Pr6F9XywW8PkP07ucxgXPUq8kfOowDaEbkO9+PUyvCC8XjRkJzOzocnrHkeT5pLtVLBOngdPZDFqtZAixfK9mO2eMYdlS3p+0Nt4QlohjRGXWjouptqy14iDhnCtgB1VjSIYCkvgNR/h+v3FSsFATbrqiwAgkkeIvOamRdX7nvjPwdqb77fWqe6e20X3CCZd5PTpHSpuh7eOidb+kLqpS3V9NYF4AFWKYCLo3om/KNTiIrzMORXNFF6LOtP68quo+U0BdUh4O2NdjutsAR6qtNbuAiPefeaJmc0BAiBh4XViFldSRMDWnhaG1ErhDGbJtKLiIxOrSksGwHHSOl+W3zx9MQGLzusSvdgV0kO/QQ7YXH6+LprgSi1WxCS4QMCfjocBS57X4AqCnbRDD6LvO+LH9Rne9CLt6aEqNVI35CbIQ3SR59V+mhy8dZId04QHaLEQmZdA4=" # my encrypted private build report email @Rotzbua
+    on_success: change # [always|never|change]
+    on_failure: always # [always|never|change]
+
 language: python
 python:
     - "2.7"
@@ -10,16 +17,16 @@ cache:
 
 env:
     # add examples here and define which boards should be tested (only compile test)
-    - PLATFORMIO_CI_SRC=examples/BasicConnectivityTest/BasicConnectivityTest.ino TESTBOARD=arduino_avr
-    - PLATFORMIO_CI_SRC=examples/TimestampUsageTest/TimestampUsageTest.ino TESTBOARD=arduino_avr
-    - PLATFORMIO_CI_SRC=examples/BasicReceiver/BasicReceiver.ino TESTBOARD=arduino_avr
-    - PLATFORMIO_CI_SRC=examples/BasicSender/BasicSender.ino TESTBOARD=arduino_avr
-    - PLATFORMIO_CI_SRC=examples/DW1000Ranging_ANCHOR/DW1000Ranging_ANCHOR.ino TESTBOARD=arduino_avr
-    - PLATFORMIO_CI_SRC=examples/DW1000Ranging_TAG/DW1000Ranging_TAG.ino TESTBOARD=arduino_avr
-    - PLATFORMIO_CI_SRC=examples/MessagePingPong/MessagePingPong.ino TESTBOARD=arduino_avr
-    - PLATFORMIO_CI_SRC=examples/RangingAnchor/RangingAnchor.ino TESTBOARD=arduino_avr
-    - PLATFORMIO_CI_SRC=examples/RangingTag/RangingTag.ino TESTBOARD=arduino_avr
-    - PLATFORMIO_CI_SRC=examples/TimestampUsageTest/TimestampUsageTest.ino TESTBOARD=arduino_avr
+    - PLATFORMIO_CI_SRC=examples/BasicConnectivityTest/BasicConnectivityTest.ino TESTBOARD=arduino_avr,arduino_arm
+    - PLATFORMIO_CI_SRC=examples/BasicReceiver/BasicReceiver.ino TESTBOARD=arduino_avr,arduino_arm
+    - PLATFORMIO_CI_SRC=examples/BasicSender/BasicSender.ino TESTBOARD=arduino_avr,arduino_arm
+    - PLATFORMIO_CI_SRC=examples/DW1000Ranging_ANCHOR/DW1000Ranging_ANCHOR.ino TESTBOARD=arduino_avr,arduino_arm
+    - PLATFORMIO_CI_SRC=examples/DW1000Ranging_TAG/DW1000Ranging_TAG.ino TESTBOARD=arduino_avr,arduino_arm
+    - PLATFORMIO_CI_SRC=examples/MessagePingPong/MessagePingPong.ino TESTBOARD=arduino_avr,arduino_arm
+    - PLATFORMIO_CI_SRC=examples/RangingAnchor/RangingAnchor.ino TESTBOARD=arduino_avr,arduino_arm
+    - PLATFORMIO_CI_SRC=examples/RangingTag/RangingTag.ino TESTBOARD=arduino_avr,arduino_arm
+    - PLATFORMIO_CI_SRC=examples/TimestampUsageTest/TimestampUsageTest.ino TESTBOARD=arduino_avr,arduino_arm
+
 
 install:
     - pip install -U platformio
@@ -28,7 +35,8 @@ script:
     # short the string comparison
     - stringContain() { [ -z "${2##*$1*}" ]; }
     # selectable board tests @Rotzbua
-    - board="arduino_avr";  if stringContain "$board" "$TESTBOARD"; then echo "check board $board"; platformio ci --lib=. --board=uno --board=megaatmega1280; else echo "skip board test of $board"; fi
-    - board="arduino_arm";  if stringContain "$board" "$TESTBOARD"; then echo "check board $board"; platformio ci --lib=. --board=due --board=zero; else echo "skip board test of $board"; fi
-    - board="teensy";  if stringContain "$board" "$TESTBOARD"; then echo "check board $board"; platformio ci --lib=. --board=teensy31; else echo "skip board test of $board"; fi
-    - board="esp";  if stringContain "$board" "$TESTBOARD"; then echo "check board $board"; platformio ci --lib=. --board=d1_mini; else echo "skip board test of $board"; fi
+    # prints only warnings and errors, to show all remove "1>/dev/null"
+    - board="arduino_avr";  if stringContain "$board" "$TESTBOARD"; then echo "check board $board"; ouput=$(platformio ci --lib=. --board=uno --board=megaatmega1280); echo "--<Result>--"; echo "$ouput" | grep -E "^(Device|Data|Program|text|[0-9])"; else echo "skip board test of $board"; fi
+    - board="arduino_arm";  if stringContain "$board" "$TESTBOARD"; then echo "check board $board"; ouput=$(platformio ci --lib=. --board=due --board=zero); echo "--<Result>--"; echo "$ouput" | grep -E "^(Device|Data|Program|text|[0-9])"; else echo "skip board test of $board"; fi
+    - board="teensy";  if stringContain "$board" "$TESTBOARD"; then echo "check board $board"; ouput=$(platformio ci --lib=. --board=teensy20 --board=teensy31); echo "--<Result>--"; echo "$ouput" | grep -E "^(Device|Data|Program|text|[0-9])"; else echo "skip board test of $board"; fi
+    - board="esp";  if stringContain "$board" "$TESTBOARD"; then echo "check board $board"; ouput=$(platformio ci --lib=. --board=d1_mini); echo "--<Result>--"; echo "$ouput" | grep -E "^(Device|Data|Program|text|[0-9])"; else echo "skip board test of $board"; fi

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Project state
 Installation
 ------------
 
+**Requires c++11 support**, Arduino IDE >= 1.6.6 support c++11.
+
  1. Get a ZIP file of the master branch or the latest release and save somewhere on your machine.
  2. Open your Arduino IDE and goto _Sketch_ / _Include Library_ / _Add .ZIP Library..._
  3. Select the downloaded ZIP file of the DW1000 library

--- a/examples/BasicSender/BasicSender.ino
+++ b/examples/BasicSender/BasicSender.ino
@@ -18,7 +18,6 @@
  * Use this to test simple sender/receiver functionality with two
  * DW1000. Complements the "BasicReceiver" example sketch. 
  */
-
 #include <SPI.h>
 #include <DW1000.h>
 
@@ -79,7 +78,7 @@ void transmitter() {
   String msg = "Hello DW1000, it's #"; msg += sentNum;
   DW1000.setData(msg);
   // delay sending the message for the given amount
-  DW1000Time deltaTime = DW1000Time(10, DW_MILLISECONDS);
+  DW1000Time deltaTime = DW1000Time(10, DW1000Time::MILLISECONDS);
   DW1000.setDelay(deltaTime);
   DW1000.startTransmit();
   delaySent = millis();
@@ -97,9 +96,9 @@ void loop() {
   DW1000Time newSentTime;
   DW1000.getTransmitTimestamp(newSentTime);
   Serial.print("Processed packet ... #"); Serial.println(sentNum);
-  Serial.print("Sent timestamp ... "); Serial.println(newSentTime.getAsFloat());
+  Serial.print("Sent timestamp ... "); Serial.println(newSentTime.getAsMicroSeconds());
   // note: delta is just for simple demo as not correct on system time counter wrap-around
-  Serial.print("DW1000 delta send time [ms] ... "); Serial.println((newSentTime.getAsFloat() - sentTime.getAsFloat()) * 1.0e-3);
+  Serial.print("DW1000 delta send time [ms] ... "); Serial.println((newSentTime.getAsMicroSeconds() - sentTime.getAsMicroSeconds()) * 1.0e-3);
   sentTime = newSentTime;
   sentNum++;
   // again, transmit some data

--- a/examples/RangingAnchor/RangingAnchor.ino
+++ b/examples/RangingAnchor/RangingAnchor.ino
@@ -134,7 +134,7 @@ void transmitPollAck() {
     DW1000.setDefaults();
     data[0] = POLL_ACK;
     // delay the same amount as ranging tag
-    DW1000Time deltaTime = DW1000Time(replyDelayTimeUS, DW_MICROSECONDS);
+    DW1000Time deltaTime = DW1000Time(replyDelayTimeUS, DW1000Time::MICROSECONDS);
     DW1000.setDelay(deltaTime);
     DW1000.setData(data, LEN_DATA);
     DW1000.startTransmit();
@@ -246,7 +246,7 @@ void loop() {
                 timeRangeSent.setTimestamp(data + 11);
                 // (re-)compute range as two-way ranging is done
                 computeRangeAsymmetric(); // CHOSEN RANGING ALGORITHM
-                transmitRangeReport(timeComputedRange.getAsFloat());
+                transmitRangeReport(timeComputedRange.getAsMicroSeconds());
                 float distance = timeComputedRange.getAsMeters();
                 Serial.print("Range: "); Serial.print(distance); Serial.print(" m");
                 Serial.print("\t RX power: "); Serial.print(DW1000.getReceivePower()); Serial.print(" dBm");

--- a/examples/RangingTag/RangingTag.ino
+++ b/examples/RangingTag/RangingTag.ino
@@ -125,7 +125,7 @@ void transmitRange() {
     DW1000.setDefaults();
     data[0] = RANGE;
     // delay sending the message and remember expected future sent timestamp
-    DW1000Time deltaTime = DW1000Time(replyDelayTimeUS, DW_MICROSECONDS);
+    DW1000Time deltaTime = DW1000Time(replyDelayTimeUS, DW1000Time::MICROSECONDS);
     timeRangeSent = DW1000.setDelay(deltaTime);
     timePollSent.getTimestamp(data + 1);
     timePollAckReceived.getTimestamp(data + 6);

--- a/examples/TimestampUsageTest/TimestampUsageTest.ino
+++ b/examples/TimestampUsageTest/TimestampUsageTest.ino
@@ -1,5 +1,6 @@
-/*
+/**
  * Copyright (c) 2015 by Thomas Trojer <thomas@trojer.net>
+ * Copyright (c) 2016 by Ludwig Grill (www.rotzbua.de); extended example
  * Decawave DW1000 library for arduino.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,7 +21,7 @@
  */
 
 #include <SPI.h>
-#include <DW1000.h>
+#include "DW1000Time.h"
 
 void setup() {
   Serial.begin(9600);
@@ -29,31 +30,72 @@ void setup() {
 
 void loop() {
   // variables for the test
-  DW1000Time time;
-  DW1000Time time2;
-  DW1000Time time3;
-  byte stamp[LEN_STAMP];
+  DW1000Time time1, time2, time3, time4;
+  byte stamp[DW1000Time::LENGTH_TIMESTAMP];
+  
   // unit test
-  Serial.print("Time is [us] ... "); Serial.println(time.getAsFloat(), 4);
-  time += DW1000Time(10, DW_MICROSECONDS);
-  Serial.print("Time is [us] ... "); Serial.println(time.getAsFloat(), 4);
-  time -= DW1000Time(500, DW_NANOSECONDS);
-  Serial.print("Time is [us] ... "); Serial.println(time.getAsFloat(), 4);
-  time2 = time;
+  Serial.println(F("simple test for + - "));
+  Serial.print(F("Time1 is   (0)[us] ... ")); Serial.println(time1.getAsMicroSeconds(), 4);
+  time1 += DW1000Time(10, DW1000Time::MICROSECONDS);
+  Serial.print(F("Time1 is  (10)[us] ... ")); Serial.println(time1.getAsMicroSeconds(), 4);
+  time1 -= DW1000Time(500, DW1000Time::NANOSECONDS);
+  Serial.print(F("Time1 is (9.5)[us] ... ")); Serial.println(time1.getAsMicroSeconds(), 4);
+  Serial.println();
+  
+  Serial.println(F("test compare"));
+  time2 = time1;
   time2 += DW1000Time(10.0f);
-  Serial.print("Time2 == Time1 ... "); Serial.println(time == time2 ? "YES" : "NO");
-  time += DW1000Time(10000, DW_NANOSECONDS);
-  Serial.print("Time2 == Time1 ... "); Serial.println(time == time2 ? "YES" : "NO");
-  memset(stamp, 0, LEN_STAMP);
+  Serial.print(F("Time2 == Time1  (NO)... ")); Serial.println(time1 == time2 ? "YES" : "NO");
+  time1 += DW1000Time(10000, DW1000Time::NANOSECONDS);
+  Serial.print(F("Time2 == Time1 (YES)... ")); Serial.println(time1 == time2 ? "YES" : "NO");
+  Serial.println();
+  
+  Serial.println(F("test different output"));
+  memset(stamp, 0, DW1000Time::LENGTH_TIMESTAMP);
   stamp[1] = 0x02; // = 512
   time2 = DW1000Time(stamp);
-  Serial.print("Time2 is [us] ... "); Serial.println(time2.getAsFloat(), 4);
-  Serial.print("Time2 range is [m] ... "); Serial.println(time2.getAsMeters(), 4);
-  time3 = DW1000Time(10, DW_SECONDS);
+  Serial.print(F("Time2 is             (512) ... ")); Serial.println(time2);
+  Serial.print(F("Time2 is      (0.0080)[us] ... ")); Serial.println(time2.getAsMicroSeconds(), 4);
+  Serial.print(F("Time2 range is (2.4022)[m] ... ")); Serial.println(time2.getAsMeters(), 4);
+  time3 = DW1000Time(10, DW1000Time::SECONDS);
   time3.getTimestamp(stamp);
   time3.setTimestamp(stamp);
-  Serial.print("Time3 is [s] ... "); Serial.println(time3.getAsFloat() * 1.0e-6, 4);
+  Serial.print(F("Time3 is (10)[s]           ... ")); Serial.println(time3.getAsMicroSeconds() * 1.0e-6, 4);
+  Serial.println();
+  
+  Serial.println(F("test negativ value"));
+  memset(stamp, 0, DW1000Time::LENGTH_TIMESTAMP);
+  time2.setTimestamp(-512);
+  Serial.print(F("Time2 is             (-512) ... ")); Serial.println(time2);
+  Serial.print(F("Time2 is      (-0.0080)[us] ... ")); Serial.println(time2.getAsMicroSeconds(), 4);
+  Serial.print(F("Time2 range is (-2.4022)[m] ... ")); Serial.println(time2.getAsMeters(), 4);
+  Serial.println();
+  
+  Serial.println(F("test calculation"));
+  time1.setTimestamp(1536);
+  time2.setTimestamp(512);
+  time3.setTimestamp(4);
+  time4 = (time1 + time2) / time3;
+  Serial.print(F("Time4 is (512) ... ")); Serial.println(time4);
+  time4 = (time1 - time2) / time3;
+  Serial.print(F("Time4 is (256) ... ")); Serial.println(time4);
+  time4 = (time1 * time3 * time2 - time2 * time3 * time2) / (time2 * time2);
+  Serial.print(F("Time4 is   (8) ... ")); Serial.println(time4);
+  Serial.println();
+  
+  Serial.println(F("test valid/maxima"));
+  time1.setTimestamp(DW1000Time::TIME_MAX);
+  time2.setTimestamp(DW1000Time::TIME_MAX);
+  time3.setTimestamp(2);
+  time4 = (time1 + time2);
+  Serial.print(F("Time4 is valid?    (NO) ... ")); Serial.println(time4.isValidTimestamp() ? "YES" : "NO");
+  Serial.print(F("Time4 is TIME_MAX  (NO) ... ")); Serial.println(time4 == DW1000Time::TIME_MAX ? "YES" : "NO");
+  time4 /= time3;
+  Serial.print(F("Time4 is valid?   (YES) ... ")); Serial.println(time4.isValidTimestamp() ? "YES" : "NO");
+  Serial.print(F("Time4 is TIME_MAX (YES) ... ")); Serial.println(time4 == DW1000Time::TIME_MAX ? "YES" : "NO");
+  
+  Serial.println();
+  
   // keep calm
   delay(10000);
 }
-

--- a/src/DW1000.cpp
+++ b/src/DW1000.cpp
@@ -1247,7 +1247,7 @@ void DW1000Class::correctTimestamp(DW1000Time& timestamp) {
 	float      rangeBias = rangeBiasLow+(rxPowerBase-rxPowerBaseLow)*(rangeBiasHigh-rangeBiasLow);
 	// range bias [mm] to timestamp modification value conversion
 	DW1000Time adjustmentTime;
-	adjustmentTime.setTimestamp((int)(rangeBias*DISTANCE_OF_RADIO_INV*0.001f));
+	adjustmentTime.setTimestamp((int)(rangeBias*DW1000Time::DISTANCE_OF_RADIO_INV*0.001f));
 	// apply correction
 	timestamp += adjustmentTime;
 }

--- a/src/DW1000.h
+++ b/src/DW1000.h
@@ -21,11 +21,6 @@
 #ifndef _DW1000_H_INCLUDED
 #define _DW1000_H_INCLUDED
 
-// Time resolution in micro-seconds of time based registers/values.
-// Each bit in a timestamp counts for a period of approx. 15.65ps
-#define TIME_RES 0.000015650040064103
-#define TIME_RES_INV 63897.6
-
 // time stamp byte length
 #define LEN_STAMP 5
 

--- a/src/DW1000CompileOptions.h
+++ b/src/DW1000CompileOptions.h
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2016 by Ludwig Grill (www.rotzbua.de)
+ * Decawave DW1000 library for arduino.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @file DW1000CompileOptions.h
+ * Here are some options to optimize code and save some ram and rom
+ * 
+ */
+
+#ifndef DW1000COMPILEOPTIONS_H
+#define DW1000COMPILEOPTIONS_H
+
+/**
+ * Printable DW1000Time object costs about: rom: 490 byte ; ram: 58 byte
+ * This option is needed because compiler can not optimize unused codes from inheritanced methods 
+ * Some examples or debug code use this
+ * Set false if you do not need it and have to save some space
+ */
+#define DW1000TIME_H_PRINTABLE true
+
+#endif // DW1000COMPILEOPTIONS_H

--- a/src/DW1000Ranging.cpp
+++ b/src/DW1000Ranging.cpp
@@ -829,7 +829,7 @@ void DW1000RangingClass::transmitPollAck(DW1000Device* myDistantDevice) {
 	_globalMac.generateShortMACFrame(data, _currentShortAddress, myDistantDevice->getByteShortAddress());
 	data[SHORT_MAC_LEN] = POLL_ACK;
 	// delay the same amount as ranging tag
-	DW1000Time deltaTime = DW1000Time(_replyDelayTimeUS, DW_MICROSECONDS);
+	DW1000Time deltaTime = DW1000Time(_replyDelayTimeUS, DW1000Time::MICROSECONDS);
 	copyShortAddress(_lastSentToShortAddress, myDistantDevice->getByteShortAddress());
 	transmit(data, deltaTime);
 }
@@ -850,7 +850,7 @@ void DW1000RangingClass::transmitRange(DW1000Device* myDistantDevice) {
 		data[SHORT_MAC_LEN+1] = _networkDevicesNumber;
 		
 		// delay sending the message and remember expected future sent timestamp
-		DW1000Time deltaTime     = DW1000Time(DEFAULT_REPLY_DELAY_TIME, DW_MICROSECONDS);
+		DW1000Time deltaTime     = DW1000Time(DEFAULT_REPLY_DELAY_TIME, DW1000Time::MICROSECONDS);
 		DW1000Time timeRangeSent = DW1000.setDelay(deltaTime);
 		
 		for(short i = 0; i < _networkDevicesNumber; i++) {
@@ -873,7 +873,7 @@ void DW1000RangingClass::transmitRange(DW1000Device* myDistantDevice) {
 		_globalMac.generateShortMACFrame(data, _currentShortAddress, myDistantDevice->getByteShortAddress());
 		data[SHORT_MAC_LEN] = RANGE;
 		// delay sending the message and remember expected future sent timestamp
-		DW1000Time deltaTime = DW1000Time(_replyDelayTimeUS, DW_MICROSECONDS);
+		DW1000Time deltaTime = DW1000Time(_replyDelayTimeUS, DW1000Time::MICROSECONDS);
 		//we get the device which correspond to the message which was sent (need to be filtered by MAC address)
 		myDistantDevice->timeRangeSent = DW1000.setDelay(deltaTime);
 		myDistantDevice->timePollSent.getTimestamp(data+1+SHORT_MAC_LEN);
@@ -898,7 +898,7 @@ void DW1000RangingClass::transmitRangeReport(DW1000Device* myDistantDevice) {
 	memcpy(data+1+SHORT_MAC_LEN, &curRange, 4);
 	memcpy(data+5+SHORT_MAC_LEN, &curRXPower, 4);
 	copyShortAddress(_lastSentToShortAddress, myDistantDevice->getByteShortAddress());
-	transmit(data, DW1000Time(_replyDelayTimeUS, DW_MICROSECONDS));
+	transmit(data, DW1000Time(_replyDelayTimeUS, DW1000Time::MICROSECONDS));
 }
 
 void DW1000RangingClass::transmitRangeFailed(DW1000Device* myDistantDevice) {

--- a/src/DW1000Time.h
+++ b/src/DW1000Time.h
@@ -1,5 +1,6 @@
-/*
+/**
  * Copyright (c) 2015 by Thomas Trojer <thomas@trojer.net>
+ * Copyright (c) 2016 by Ludwig Grill (www.rotzbua.de); refactored class
  * Decawave DW1000 library for arduino.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,81 +18,127 @@
  * @file DW1000Time.h
  * Arduino driver library timestamp wrapper (header file) for the Decawave 
  * DW1000 UWB transceiver IC.
+ * 
+ * @TODO
+ * - avoid/remove floating operations, expensive on most microprocessors
+ * 
+ * @note
+ * comments in cpp file, makes .h smaller and gives a better overview about
+ * available methods and variables.
  */
 
-#ifndef _DW1000Time_H_INCLUDED
-#define _DW1000Time_H_INCLUDED
-
-// Time resolution in micro-seconds of time based registers/values.
-// Each bit in a timestamp counts for a period of approx. 15.65ps
-#define TIME_RES 0.000015650040064103f
-#define TIME_RES_INV 63897.6f
-
-// Speed of radio waves [m/s] * timestamp resolution [~15.65ps] of DW1000
-#define DISTANCE_OF_RADIO 0.0046917639786159f
-#define DISTANCE_OF_RADIO_INV 213.139451293f
-
-// time stamp byte length
-#define LEN_STAMP 5
-
-
-// timer/counter overflow (40 bits)
-#define TIME_OVERFLOW 1099511627776
-
-// time factors (relative to [us]) for setting delayed transceive
-#define DW_SECONDS 1e6
-#define DW_MILLISECONDS 1e3
-#define DW_MICROSECONDS 1
-#define DW_NANOSECONDS 1e-3
+#ifndef DW1000TIME_H
+#define DW1000TIME_H
 
 #include <Arduino.h>
+#include <stdint.h>
+#include <inttypes.h>
+#include "DW1000CompileOptions.h"
+#include "deprecated.h"
+#include "require_cpp11.h"
 
+#if DW1000TIME_H_PRINTABLE
+class DW1000Time : public Printable {
+#else
 class DW1000Time {
+#endif // DW1000Time_H_PRINTABLE
 public:
+	// Time resolution in micro-seconds of time based registers/values.
+	// Each bit in a timestamp counts for a period of approx. 15.65ps
+	static constexpr float TIME_RES     = 0.000015650040064103f;
+	static constexpr float TIME_RES_INV = 63897.6f;
+	
+	// Speed of radio waves [m/s] * timestamp resolution [~15.65ps] of DW1000
+	static constexpr float DISTANCE_OF_RADIO     = 0.0046917639786159f;
+	static constexpr float DISTANCE_OF_RADIO_INV = 213.139451293f;
+	
+	// timestamp byte length - 40 bit -> 5 byte
+	static constexpr uint8_t LENGTH_TIMESTAMP = 5;
+	
+	// timer/counter overflow (40 bits) -> 4overflow approx. every 17.2 seconds
+	static constexpr int64_t TIME_OVERFLOW = 0x10000000000; //1099511627776LL
+	static constexpr int64_t TIME_MAX      = 0xffffffffff;
+	
+	// time factors (relative to [us]) for setting delayed transceive
+	// TODO use non float
+	static constexpr float SECONDS      = 1e6;
+	static constexpr float MILLISECONDS = 1e3;
+	static constexpr float MICROSECONDS = 1;
+	static constexpr float NANOSECONDS  = 1e-3;
+	
+	// constructor
 	DW1000Time();
-	DW1000Time(long long int time);
-	DW1000Time(float timeUs);
+	DW1000Time(int64_t time);
 	DW1000Time(byte data[]);
-	DW1000Time(long value, float factorUs);
 	DW1000Time(const DW1000Time& copy);
+	DW1000Time(float timeUs);
+	DW1000Time(int32_t value, float factorUs);
 	~DW1000Time();
 	
+	// setter
+	// dw1000 timestamp, increase of +1 approx approx. 15.65ps real time
+	void setTimestamp(int64_t value);
+	void setTimestamp(byte data[]);
+	void setTimestamp(const DW1000Time& copy);
+	
+	// real time in us
 	void setTime(float timeUs);
-	void setTime(long value, float factorUs);
+	void setTime(int32_t value, float factorUs);
 	
+	// getter
+	int64_t getTimestamp() const;
+	void    getTimestamp(byte data[]) const;
+	
+	DEPRECATED_MSG("use getAsMicroSeconds()")
 	float getAsFloat() const;
-	void  getAsBytes(byte data[]) const;
+	// getter, convert the timestamp to usual units
+	float getAsMicroSeconds() const;
+	//void getAsBytes(byte data[]) const; // TODO check why it is here, is it old version of getTimestamp(byte) ?
 	float getAsMeters() const;
-	
-	void          getTimestamp(byte data[]) const;
-	long long int getTimestamp() const;
-	void          setTimestamp(byte data[]);
-	void          setTimestamp(const DW1000Time& copy);
-	void          setTimestamp(int value);
 	
 	DW1000Time& wrap();
 	
+	// self test
+	bool isValidTimestamp();
+	
+	// assign
 	DW1000Time& operator=(const DW1000Time& assign);
+	// add
 	DW1000Time& operator+=(const DW1000Time& add);
 	DW1000Time operator+(const DW1000Time& add) const;
+	// subtract
 	DW1000Time& operator-=(const DW1000Time& sub);
 	DW1000Time operator-(const DW1000Time& sub) const;
+	// multiply
+	// multiply with float cause lost in accuracy, because float calculates only with 23bit matise
 	DW1000Time& operator*=(float factor);
-	DW1000Time operator*(const DW1000Time& factor) const;
-	DW1000Time& operator*=(const DW1000Time& factor);
 	DW1000Time operator*(float factor) const;
+	// no accuracy lost
+	DW1000Time& operator*=(const DW1000Time& factor);
+	DW1000Time operator*(const DW1000Time& factor) const;
+	// divide
+	// divide with float cause lost in accuracy, because float calculates only with 23bit matise
 	DW1000Time& operator/=(float factor);
 	DW1000Time operator/(float factor) const;
+	// no accuracy lost
 	DW1000Time& operator/=(const DW1000Time& factor);
 	DW1000Time operator/(const DW1000Time& factor) const;
+	// compare
 	boolean operator==(const DW1000Time& cmp) const;
 	boolean operator!=(const DW1000Time& cmp) const;
-	
-	void print();
 
+#ifdef DW1000TIME_H_PRINTABLE
+	// print to serial for debug
+	DEPRECATED_MSG("use Serial.print(object)")
+	void print();
+	// for usage with e.g. Serial.print()
+	size_t printTo(Print& p) const;
+#endif // DW1000Time_H_PRINTABLE
+	
 private:
-	long long int _timestamp;
+	// timestamp size from dw1000 is 40bit, maximum number 1099511627775
+	// signed because you can calculate with DW1000Time; negative values are possible errors
+	int64_t _timestamp = 0;
 };
 
-#endif
-
+#endif // DW1000Time_H

--- a/src/deprecated.h
+++ b/src/deprecated.h
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) 2016 by Ludwig Grill (www.rotzbua.de)
+ * Simple deprecated workaround for Arduino IDE
+ * IDE 1.6.8 use gcc 4.8 which do not support c++14 [[deprecated]]
+ * Later versions should support c++14, then use c++14 syntax
+ */
+#ifndef DEPRECATED_H
+#define DEPRECATED_H
+
+#ifdef __has_cpp_attribute
+#if __has_cpp_attribute(deprecated)
+#define DEPRECATED [[deprecated]]
+#define DEPRECATED_MSG(msg) [[deprecated(msg)]]
+#endif // __has_cpp_attribute(deprecated)
+#else
+#define DEPRECATED __attribute__((deprecated))
+#define DEPRECATED_MSG(msg) __attribute__((deprecated(msg)))
+#endif // __has_cpp_attribute
+
+#endif // DEPRECATED_H

--- a/src/require_cpp11.h
+++ b/src/require_cpp11.h
@@ -1,6 +1,12 @@
-/*
+/**
+ * Copyright (c) 2016 by Ludwig Grill (www.rotzbua.de)
  * Throws error if c++11 is not supported
  */
+#ifndef REQUIRE_CPP11_H
+#define REQUIRE_CPP11_H
+
 #if __cplusplus < 201103L
-#error "This library needs at least a C++11 compliant compiler, maybe compiler argument for C++11 support is missing or if you use Arduino IDE upgrade to version >=1.6.8"
+#error "This library needs at least a C++11 compliant compiler, maybe compiler argument for C++11 support is missing or if you use Arduino IDE upgrade to version >=1.6.6"
 #endif
+
+#endif // REQUIRE_CPP11_H


### PR DESCRIPTION
Hi, 
I refactored DW1000Time. Please somebody review it before merge.
Note: `constexpr` is a type safe way to replace preprocessors simple `#define`
Best

Changes:
- DW1000Time now printable with Serial.print(*DW1000Time*)
- costs more ram and rom so optional deactivate it by new DW1000CompileOptions.h
- deprecated getAsFloat and print
- replace getAsFloat with getAsMicroseconds
- now use fixed integers, more portable
- removed some float operations
- extended example TimestampUsageTest.ino
- use modern c++11