### PR TITLE
this change provides access to the DW1000 temperature and voltage

### DIFF
--- a/src/DW1000.cpp
+++ b/src/DW1000.cpp
@@ -53,8 +53,8 @@ byte       DW1000Class::_chanctrl[LEN_CHAN_CTRL];
 byte       DW1000Class::_networkAndAddress[LEN_PANADR];
 
 // monitoring
-short DW1000Class::_vmeas3v3 = 0;
-short DW1000Class::_tmeas23C = 0;
+int DW1000Class::_vmeas3v3 = 0;
+int DW1000Class::_tmeas23C = 0;
 
 // driver internal state
 byte       DW1000Class::_extendedFrameLength = FRAME_LENGTH_NORMAL;
@@ -820,8 +820,8 @@ void DW1000Class::getTempAndVbat(float& temp, float& vbat) {
 	byte sar_lvbat = 0; readBytes(TX_CAL, 0x03, &sar_lvbat, 1);
 	byte sar_ltemp = 0; readBytes(TX_CAL, 0x04, &sar_ltemp, 1);
 
-	vbat = ((short)(sar_lvbat&0xFF) - _vmeas3v3) / 173.0f + 3.3f;
-	temp = ((short)(sar_ltemp&0xFF) - _tmeas23C) * 1.14f + 23.0f;
+	vbat = ((int)(sar_lvbat&0xFF) - _vmeas3v3) / 173.0f + 3.3f;
+	temp = ((int)(sar_ltemp&0xFF) - _tmeas23C) * 1.14f + 23.0f;
 }
 
 void DW1000Class::setEUI(char eui[]) {

--- a/src/DW1000.h
+++ b/src/DW1000.h
@@ -223,6 +223,8 @@
 #define TX_CAL 0x2A
 #define TC_PGDELAY_SUB 0x0B
 #define LEN_TC_PGDELAY 1
+#define TC_SARC 0x00
+#define TC_SARL 0x03
 
 // FS_CTRL (for re-tuning only)
 #define FS_CTRL 0x2B
@@ -546,6 +548,9 @@ public:
 	static int  nibbleFromChar(char c);
 	static void convertToByte(char string[], byte* eui_byte);
 	
+	// host-initiated reading of temperature and battery voltage
+	static void getTempAndVbat(float& temp, float& vbat);
+
 	// transmission/reception bit rate
 	static const byte TRX_RATE_110KBPS  = 0x00;
 	static const byte TRX_RATE_850KBPS  = 0x01;
@@ -633,6 +638,10 @@ private:
 	static byte _sysmask[LEN_SYS_MASK];
 	static byte _chanctrl[LEN_CHAN_CTRL];
 	
+	/* device status monitoring */
+	static short _vmeas3v3;
+	static short _tmeas23C;
+
 	/* PAN and short address. */
 	static byte _networkAndAddress[LEN_PANADR];
 	

--- a/src/DW1000.h
+++ b/src/DW1000.h
@@ -639,8 +639,8 @@ private:
 	static byte _chanctrl[LEN_CHAN_CTRL];
 	
 	/* device status monitoring */
-	static short _vmeas3v3;
-	static short _tmeas23C;
+	static int _vmeas3v3;
+	static int _tmeas23C;
 
 	/* PAN and short address. */
 	static byte _networkAndAddress[LEN_PANADR];


### PR DESCRIPTION
The reference temperature and voltage, determined during production calibration, are read from OTP and stored in a static member variable. The host can then request temperature and voltage by calling the static member function as follows:

float temp = 0, vbat = 0;
DW1000.getTempAndVbat(temp, vbat);