### PR TITLE
add support for GPIO led blinking

### DIFF
--- a/src/DW1000.cpp
+++ b/src/DW1000.cpp
@@ -221,6 +221,33 @@ void DW1000Class::enableClock(byte clock) {
 	writeBytes(PMSC, PMSC_CTRL0_SUB, pmscctrl0, 2);
 }
 
+void DW1000Class::enableDebounceClock() {
+	byte pmscctrl0[LEN_PMSC_CTRL0];
+	memset(pmscctrl0, 0, LEN_PMSC_CTRL0);
+	readBytes(PMSC, PMSC_CTRL0_SUB, pmscctrl0, LEN_PMSC_CTRL0);
+	setBit(pmscctrl0, LEN_PMSC_CTRL0, GPDCE_BIT, 1);
+	setBit(pmscctrl0, LEN_PMSC_CTRL0, KHZCLKEN_BIT, 1);
+	writeBytes(PMSC, PMSC_CTRL0_SUB, pmscctrl0, LEN_PMSC_CTRL0);
+}
+
+void DW1000Class::enableLedBlinking() {
+	byte pmscledc[LEN_PMSC_LEDC];
+	memset(pmscledc, 0, LEN_PMSC_LEDC);
+	readBytes(PMSC, PMSC_LEDC_SUB, pmscledc, LEN_PMSC_LEDC);
+	setBit(pmscledc, LEN_PMSC_LEDC, BLNKEN, 1);
+	writeBytes(PMSC, PMSC_LEDC_SUB, pmscledc, LEN_PMSC_LEDC);
+}
+
+void DW1000Class::setGPIOMode(uint8_t msgp, uint8_t mode) {
+	byte gpiomode[LEN_GPIO_MODE];
+	memset(gpiomode, 0, LEN_GPIO_MODE);
+	readBytes(GPIO_CTRL, GPIO_MODE_SUB, gpiomode, LEN_GPIO_MODE);
+	for (char i = 0; i < 2; i++){
+		setBit(gpiomode, LEN_GPIO_MODE, msgp + i, (mode >> i) & 1);
+	}
+	writeBytes(GPIO_CTRL, GPIO_MODE_SUB, gpiomode, LEN_GPIO_MODE);
+}
+
 void DW1000Class::reset() {
 	if(_rst == 0xff) {
 		softReset();

--- a/src/DW1000.h
+++ b/src/DW1000.h
@@ -76,6 +76,21 @@ public:
 	static void end();
 	
 	/** 
+	Enable debounce Clock, used to clock the LED blinking
+	*/
+	static void enableDebounceClock();
+
+	/**
+	Enable led blinking feature
+	*/
+	static void enableLedBlinking();
+
+	/**
+	Set GPIO mode
+	*/
+	static void setGPIOMode(uint8_t msgp, uint8_t mode);
+
+	/**
 	Resets all connected or the currently selected DW1000 chip. A hard reset of all chips
 	is preferred, although a soft reset of the currently selected one is executed if no 
 	reset pin has been specified (when using `begin(int)`, instead of `begin(int, int)`).

--- a/src/DW1000Constants.h
+++ b/src/DW1000Constants.h
@@ -238,10 +238,33 @@
 // PMSC
 #define PMSC 0x36
 #define PMSC_CTRL0_SUB 0x00
+#define PMSC_LEDC_SUB 0x28
 #define LEN_PMSC_CTRL0 4
+#define LEN_PMSC_LEDC 4
+#define GPDCE_BIT 18
+#define KHZCLKEN_BIT 23
+#define BLNKEN 8
 
 // TX_ANTD Antenna delays
 #define TX_ANTD 0x18
 #define LEN_TX_ANTD 2
+
+// GPIO
+#define GPIO_CTRL 0x26
+#define GPIO_MODE_SUB 0x00
+#define LEN_GPIO_MODE 4
+
+#define MSGP0 6
+#define MSGP1 8
+#define MSGP2 10
+#define MSGP3 12
+#define MSGP4 14
+#define MSGP5 16
+#define MSGP6 18
+#define MSGP7 20
+#define MSGP8 22
+
+#define GPIO_MODE 0
+#define LED_MODE 1
 
 #endif


### PR DESCRIPTION
Minimal support for GPIO led blinking (issue #59)

Usage:
```
DW1000.enableDebounceClock();
DW1000.enableLedBlinking();
// enable GPIO2/RXLED blinking
DW1000.setGPIOMode(MSGP2, LED_MODE);
// enable GPIO3/TXLED blinking
DW1000.setGPIOMode(MSGP3, LED_MODE);
```