### PR TITLE
Preserve pmscctrl0[1] on lde load

### DIFF
--- a/src/DW1000.cpp
+++ b/src/DW1000.cpp
@@ -195,7 +195,7 @@ void DW1000Class::manageLDE() {
 	writeBytes(OTP_IF, OTP_CTRL_SUB, otpctrl, 2);
 	delay(5);
 	pmscctrl0[0] = 0x00;
-	pmscctrl0[1] = 0x02;
+	pmscctrl0[1] &= 0x02;
 	writeBytes(PMSC, PMSC_CTRL0_SUB, pmscctrl0, 2);
 }
 


### PR DESCRIPTION
Found the cause of issue #167 in lde load code.
DW1000 user manual doesn't clarify if pmscctrl0[1] must be overwritten completly or only the first two bit must be set.

This PR implement the second beaviour, confirmed by the deca driver source code.
https://github.com/lab11/dw1000-driver/blob/master/deca_device.c#L2621

Solves #167 as ADCCE bit and undocumented bit 9 of PMSC_CTRL0 are preserved to their state (1).