### PR TITLE
Bug in clearAllStatus()

### DIFF
--- a/src/DW1000.cpp
+++ b/src/DW1000.cpp
@@ -1392,7 +1392,8 @@ boolean DW1000Class::isClockProblem() {
 }
 
 void DW1000Class::clearAllStatus() {
-	memset(_sysstatus, 0, LEN_SYS_STATUS);
+	//Latched bits in status register are reset by writing 1 to them
+	memset(_sysstatus, 0xff, LEN_SYS_STATUS);
 	writeBytes(SYS_STATUS, NO_SUB, _sysstatus, LEN_SYS_STATUS);
 }
 


### PR DESCRIPTION
Bug in clearAllStatus()-- 

Previous implementation has writing a value of 0 to every bit in the status register, while per the user manual latched bits in sys_status are cleared by writing 1 to them. clearReceiveStatus() and clearTransmitStatus() follow this by using setBit() to write a 1 to specific bits in sys_status. clearAllStatus() should accordingly write a 1 to every bit in sys_status, and can do so by calling memset with 0xff as the value to write to each byte.

When I tested the previous version of clearAllStatus() it resulted in no change to the internal status register of the DW1000 (which can be read by calling readSystemEventStatusRegister()). On the other hand, calling clearAllStatus() with 0xff as the value to write resulted in a fully cleared (zeroed out) status register for the DW1000.