### PR TITLE
Updated isReceiveTimeout() to check for Preamble and SFD timeout as well

### DIFF
--- a/src/DW1000.cpp
+++ b/src/DW1000.cpp
@@ -1378,7 +1378,7 @@ boolean DW1000Class::isReceiveFailed() {
 }
 
 boolean DW1000Class::isReceiveTimeout() {
-	return (getBit(_sysstatus, LEN_SYS_STATUS, RXRFTO_BIT) | getBit(_sysstatus, LEN_SYS_STATUS, RXPTO_BIT) | getBit(_sysstatus, LEN_SYS_STATUS, RXSFDTO_BIT))
+	return (getBit(_sysstatus, LEN_SYS_STATUS, RXRFTO_BIT) | getBit(_sysstatus, LEN_SYS_STATUS, RXPTO_BIT) | getBit(_sysstatus, LEN_SYS_STATUS, RXSFDTO_BIT));
 }
 
 boolean DW1000Class::isClockProblem() {

--- a/src/DW1000.cpp
+++ b/src/DW1000.cpp
@@ -1377,6 +1377,7 @@ boolean DW1000Class::isReceiveFailed() {
 	return false;
 }
 
+//Checks to see any of the three timeout bits in sysstatus are high (RXRFTO (Frame Wait timeout), RXPTO (Preamble timeout), RXSFDTO (Start frame delimiter(?) timeout).
 boolean DW1000Class::isReceiveTimeout() {
 	return (getBit(_sysstatus, LEN_SYS_STATUS, RXRFTO_BIT) | getBit(_sysstatus, LEN_SYS_STATUS, RXPTO_BIT) | getBit(_sysstatus, LEN_SYS_STATUS, RXSFDTO_BIT));
 }

--- a/src/DW1000.cpp
+++ b/src/DW1000.cpp
@@ -1378,7 +1378,7 @@ boolean DW1000Class::isReceiveFailed() {
 }
 
 boolean DW1000Class::isReceiveTimeout() {
-	return getBit(_sysstatus, LEN_SYS_STATUS, RXRFTO_BIT);
+	return (getBit(_sysstatus, LEN_SYS_STATUS, RXRFTO_BIT) | getBit(_sysstatus, LEN_SYS_STATUS, RXPTO_BIT) | getBit(_sysstatus, LEN_SYS_STATUS, RXSFDTO_BIT))
 }
 
 boolean DW1000Class::isClockProblem() {


### PR DESCRIPTION
isReceiveTimeout() currently only checks to see if RXRFTO is high, but there are two other potential timeout flags-- the RX SFD timeout is enabled by default and the RX Preamble timeout can be enabled in the DRX_PRETOC (sub)register. It seems like this function should check all three of these bits rather than just RXRFTO.

Will make separate pull request to include #defines for RXPTO_BIT and RXSFDTO_BIT (21 and 26, respectively)