### PR TITLE
Update DW1000.cpp

### DIFF
--- a/src/DW1000.cpp
+++ b/src/DW1000.cpp
@@ -96,7 +96,12 @@ const byte DW1000Class::BIAS_900_16[] = {137, 122, 105, 88, 69, 47, 25, 0, 21, 4
 const byte DW1000Class::BIAS_900_64[] = {147, 133, 117, 99, 75, 50, 29, 0, 24, 45, 63, 76, 87, 98, 116, 122, 132, 142};
 */
 // SPI settings
-const SPISettings DW1000Class::_fastSPI = SPISettings(16000000L, MSBFIRST, SPI_MODE0);
+#ifndef ESP8266
+	const SPISettings DW1000Class::_fastSPI = SPISettings(16000000L, MSBFIRST, SPI_MODE0);
+#else
+	// default ESP8266 frequency is 80 Mhz, thus divide by 4 is 20 MHz
+	const SPISettings DW1000Class::_fastSPI = SPISettings(20000000L, MSBFIRST, SPI_MODE0);
+#endif
 const SPISettings DW1000Class::_slowSPI = SPISettings(2000000L, MSBFIRST, SPI_MODE0);
 const SPISettings* DW1000Class::_currentSPI = &_fastSPI;
 


### PR DESCRIPTION
While using the library with an ESP12e, the SPI clock has to be changed to 20 MHz as 16 Mhz can not be generated while running with 80 MHz.