### PR TITLE
Update DW1000.cpp

### DIFF
--- a/src/DW1000.cpp
+++ b/src/DW1000.cpp
@@ -157,6 +157,8 @@ void DW1000Class::reselect(uint8_t ss) {
 void DW1000Class::begin(uint8_t irq, uint8_t rst) {
 	// generous initial init/wake-up-idle delay
 	delay(5);
+	// Configure the IRQ pin as INPUT
+    	pinMode(irq, INPUT);
 	// start SPI
 	SPI.begin();
 #ifndef ESP8266


### PR DESCRIPTION
For ESP8266, the irq must be forced to be an input manually, see https://github.com/thotro/arduino-dw1000/issues/132.