### PR TITLE
Add support for deep sleep and spi wake-up

### DIFF
--- a/src/DW1000.cpp
+++ b/src/DW1000.cpp
@@ -67,6 +67,8 @@ boolean    DW1000Class::_frameCheck          = true;
 boolean    DW1000Class::_permanentReceive    = false;
 uint8_t    DW1000Class::_deviceMode          = IDLE_MODE; // TODO replace by enum
 
+boolean    DW1000Class::_debounceClockEnabled = false;
+
 // modes of operation
 // TODO use enum external, not config array
 // this declaration is needed to make variables accessible while runtime from external code
@@ -235,6 +237,7 @@ void DW1000Class::enableDebounceClock() {
 	setBit(pmscctrl0, LEN_PMSC_CTRL0, GPDCE_BIT, 1);
 	setBit(pmscctrl0, LEN_PMSC_CTRL0, KHZCLKEN_BIT, 1);
 	writeBytes(PMSC, PMSC_CTRL0_SUB, pmscctrl0, LEN_PMSC_CTRL0);
+        _debounceClockEnabled = true;
 }
 
 void DW1000Class::enableLedBlinking() {
@@ -254,6 +257,48 @@ void DW1000Class::setGPIOMode(uint8_t msgp, uint8_t mode) {
 	}
 	writeBytes(GPIO_CTRL, GPIO_MODE_SUB, gpiomode, LEN_GPIO_MODE);
 }
+
+void DW1000Class::deepSleep() {
+	byte aon_wcfg[LEN_AON_WCFG];
+	memset(aon_wcfg, 0, LEN_AON_WCFG);
+	readBytes(AON, AON_WCFG_SUB, aon_wcfg, LEN_AON_WCFG);
+	setBit(aon_wcfg, LEN_AON_WCFG, ONW_LDC_BIT, true);
+	setBit(aon_wcfg, LEN_AON_WCFG, ONW_LDD0_BIT, true);
+	writeBytes(AON, AON_WCFG_SUB, aon_wcfg, LEN_AON_WCFG);
+
+	byte pmsc_ctrl1[LEN_PMSC_CTRL1];
+	memset(pmsc_ctrl1, 0, LEN_PMSC_CTRL1);
+	readBytes(PMSC, PMSC_CTRL1_SUB, pmsc_ctrl1, LEN_PMSC_CTRL1);
+	setBit(pmsc_ctrl1, LEN_PMSC_CTRL1, ATXSLP_BIT, false);
+	setBit(pmsc_ctrl1, LEN_PMSC_CTRL1, ARXSLP_BIT, false);
+	writeBytes(PMSC, PMSC_CTRL1_SUB, pmsc_ctrl1, LEN_PMSC_CTRL1);
+
+	byte aon_cfg0[LEN_AON_CFG0];
+	memset(aon_cfg0, 0, LEN_AON_CFG0);
+	readBytes(AON, AON_CFG0_SUB, aon_cfg0, LEN_AON_CFG0);
+	setBit(aon_cfg0, LEN_AON_CFG0, WAKE_SPI_BIT, true);
+	setBit(aon_cfg0, LEN_AON_CFG0, WAKE_PIN_BIT, true);
+	setBit(aon_cfg0, LEN_AON_CFG0, WAKE_CNT_BIT, false);
+	setBit(aon_cfg0, LEN_AON_CFG0, SLEEP_EN_BIT, true);
+	writeBytes(AON, AON_CFG0_SUB, aon_cfg0, LEN_AON_CFG0);
+
+	byte aon_ctrl[LEN_AON_CTRL];
+	memset(aon_ctrl, 0, LEN_AON_CTRL);
+	readBytes(AON, AON_CTRL_SUB, aon_ctrl, LEN_AON_CTRL);
+	setBit(aon_ctrl, LEN_AON_CTRL, UPL_CFG_BIT, true);
+	setBit(aon_ctrl, LEN_AON_CTRL, SAVE_BIT, true);
+	writeBytes(AON, AON_CTRL_SUB, aon_ctrl, LEN_AON_CTRL);
+}
+
+void DW1000Class::spiWakeup(){
+        digitalWrite(_ss, LOW);
+        delay(2);
+        digitalWrite(_ss, HIGH);
+        if (_debounceClockEnabled){
+                DW1000Class::enableDebounceClock();
+        }
+}
+
 
 void DW1000Class::reset() {
 	if(_rst == 0xff) {

--- a/src/DW1000.h
+++ b/src/DW1000.h
@@ -90,6 +90,16 @@ public:
 	*/
 	static void setGPIOMode(uint8_t msgp, uint8_t mode);
 
+        /**
+        Enable deep sleep mode
+        */
+        static void deepSleep();
+
+        /**
+        Wake-up from deep sleep by toggle chip select pin
+        */
+        static void spiWakeup();
+
 	/**
 	Resets all connected or the currently selected DW1000 chip. A hard reset of all chips
 	is preferred, although a soft reset of the currently selected one is executed if no 
@@ -448,7 +458,10 @@ public:
 	
 	// whether RX or TX is active
 	static uint8_t _deviceMode;
-	
+
+	// whether debounce clock is active
+	static boolean _debounceClockEnabled;
+
 	/* Arduino interrupt handler */
 	static void handleInterrupt();
 	

--- a/src/DW1000Constants.h
+++ b/src/DW1000Constants.h
@@ -237,15 +237,39 @@
 #define LEN_FS_PLLTUNE 1
 #define LEN_FS_XTALT 1
 
+// AON
+#define AON 0x2C
+#define AON_WCFG_SUB 0x00
+#define LEN_AON_WCFG 2
+#define ONW_LDC_BIT 6
+#define ONW_LDD0_BIT 12
+#define AON_CTRL_SUB 0x02
+#define LEN_AON_CTRL 1
+#define RESTORE_BIT 0
+#define SAVE_BIT 1
+#define UPL_CFG_BIT 2
+
+#define AON_CFG0_SUB 0x06
+#define LEN_AON_CFG0 4
+#define SLEEP_EN_BIT 0
+#define WAKE_PIN_BIT 1
+#define WAKE_SPI_BIT 2
+#define WAKE_CNT_BIT 3
+
 // PMSC
 #define PMSC 0x36
 #define PMSC_CTRL0_SUB 0x00
+#define PMSC_CTRL1_SUB 0x04
 #define PMSC_LEDC_SUB 0x28
 #define LEN_PMSC_CTRL0 4
+#define LEN_PMSC_CTRL1 4
 #define LEN_PMSC_LEDC 4
 #define GPDCE_BIT 18
 #define KHZCLKEN_BIT 23
 #define BLNKEN 8
+
+#define ATXSLP_BIT 11
+#define ARXSLP_BIT 12
 
 // TX_ANTD Antenna delays
 #define TX_ANTD 0x18


### PR DESCRIPTION
This commit implements DW1000 deep sleep as per #30.
Simply use DW1000.deepSleep() to enter deep sleep state and use wake pin or DW1000.spiWakeup() to wake-up the chip.

On wake-up the configuration is automaticaly restored from AON memory. Some registers may be not correctly restored.
I actualy found that the GPDCE bit in PMSC_CTRL0 is not restored on wake-up and I added a fix.