### PR TITLE
fix third anchor loosing connection

### DIFF
--- a/src/DW1000Ranging.cpp
+++ b/src/DW1000Ranging.cpp
@@ -38,7 +38,7 @@ DW1000Device DW1000RangingClass::_networkDevices[MAX_DEVICES];
 byte         DW1000RangingClass::_currentAddress[8];
 byte         DW1000RangingClass::_currentShortAddress[2];
 byte         DW1000RangingClass::_lastSentToShortAddress[2];
-uint8_t      DW1000RangingClass::_networkDevicesNumber = 0; // TODO short, 8bit?
+volatile uint8_t DW1000RangingClass::_networkDevicesNumber = 0; // TODO short, 8bit?
 int16_t      DW1000RangingClass::_lastDistantDevice    = 0; // TODO short, 8bit?
 DW1000Mac    DW1000RangingClass::_globalMac;
 
@@ -476,7 +476,7 @@ void DW1000RangingClass::loop() {
 			DW1000Device* myDistantDevice = searchDistantDevice(address);
 			
 			
-			if(myDistantDevice == NULL) {
+			if((_networkDevicesNumber != 0) && (myDistantDevice == NULL)) {
 				Serial.println("Not found");
 				//we don't have the short address of the device in memory
 				/*

--- a/src/DW1000Ranging.h
+++ b/src/DW1000Ranging.h
@@ -123,7 +123,7 @@ public:
 private:
 	//other devices in the network
 	static DW1000Device _networkDevices[MAX_DEVICES];
-	static uint8_t      _networkDevicesNumber;
+	static volatile uint8_t _networkDevicesNumber;
 	static int16_t      _lastDistantDevice;
 	static byte         _currentAddress[8];
 	static byte         _currentShortAddress[2];


### PR DESCRIPTION
This bug is reported in several issues (#116, #179). Some solutions have
been implemented like here:
https://github.com/ybc82/arduino-dw1000/commit/22d215eeb3ebf800b5df9a5dea8f82ec601283cd
This pull request have been succesfully tested with 3 anchors and 1 tag.