### PR TITLE
add option to set anchors static short addresses

### DIFF
--- a/src/DW1000Ranging.cpp
+++ b/src/DW1000Ranging.cpp
@@ -159,17 +159,24 @@ void DW1000RangingClass::generalStart() {
 }
 
 
-void DW1000RangingClass::startAsAnchor(char address[], const byte mode[]) {
+void DW1000RangingClass::startAsAnchor(char address[], const byte mode[], const bool randomShortAddress) {
 	//save the address
 	DW1000.convertToByte(address, _currentAddress);
 	//write the address on the DW1000 chip
 	DW1000.setEUI(address);
 	Serial.print("device address: ");
 	Serial.println(address);
-	//we need to define a random short address:
-	randomSeed(analogRead(0));
-	_currentShortAddress[0] = random(0, 256);
-	_currentShortAddress[1] = random(0, 256);
+	if (randomShortAddress) {
+		//we need to define a random short address:
+		randomSeed(analogRead(0));
+		_currentShortAddress[0] = random(0, 256);
+		_currentShortAddress[1] = random(0, 256);
+	}
+	else {
+		// we use first two bytes in addess for short address
+		_currentShortAddress[0] = _currentAddress[0];
+		_currentShortAddress[1] = _currentAddress[1];
+	}
 	
 	//we configur the network for mac filtering
 	//(device Address, network ID, frequency)
@@ -185,17 +192,24 @@ void DW1000RangingClass::startAsAnchor(char address[], const byte mode[]) {
 	
 }
 
-void DW1000RangingClass::startAsTag(char address[], const byte mode[]) {
+void DW1000RangingClass::startAsTag(char address[], const byte mode[], const bool randomShortAddress) {
 	//save the address
 	DW1000.convertToByte(address, _currentAddress);
 	//write the address on the DW1000 chip
 	DW1000.setEUI(address);
 	Serial.print("device address: ");
 	Serial.println(address);
-	//we need to define a random short address:
-	randomSeed(analogRead(0));
-	_currentShortAddress[0] = random(0, 256);
-	_currentShortAddress[1] = random(0, 256);
+	if (randomShortAddress) {
+		//we need to define a random short address:
+		randomSeed(analogRead(0));
+		_currentShortAddress[0] = random(0, 256);
+		_currentShortAddress[1] = random(0, 256);
+	}
+	else {
+		// we use first two bytes in addess for short address
+		_currentShortAddress[0] = _currentAddress[0];
+		_currentShortAddress[1] = _currentAddress[1];
+	}
 	
 	//we configur the network for mac filtering
 	//(device Address, network ID, frequency)

--- a/src/DW1000Ranging.h
+++ b/src/DW1000Ranging.h
@@ -78,8 +78,8 @@ public:
 	static void    initCommunication(uint8_t myRST = DEFAULT_RST_PIN, uint8_t mySS = DEFAULT_SPI_SS_PIN, uint8_t myIRQ = 2);
 	static void    configureNetwork(uint16_t deviceAddress, uint16_t networkId, const byte mode[]);
 	static void    generalStart();
-	static void    startAsAnchor(char address[], const byte mode[]);
-	static void    startAsTag(char address[], const byte mode[]);
+	static void    startAsAnchor(char address[], const byte mode[], const bool randomShortAddress = true);
+	static void    startAsTag(char address[], const byte mode[], const bool randomShortAddress = true);
 	static boolean addNetworkDevices(DW1000Device* device, boolean shortAddress);
 	static boolean addNetworkDevices(DW1000Device* device);
 	static void    removeNetworkDevices(int16_t index);


### PR DESCRIPTION
The first two bytes of the full address can be used as static short
address. By default, the previous behavior (random address) is used.

See #79