### PR TITLE
Fixed errors and inconsistencies in DW1000.cpp

### DIFF
--- a/src/DW1000.cpp
+++ b/src/DW1000.cpp
@@ -1336,10 +1336,10 @@ void DW1000Class::correctTimestamp(DW1000Time& timestamp) {
 	float rxPowerBase     = -(getReceivePower()+61.0f)*0.5f;
 	int16_t   rxPowerBaseLow  = (int16_t)rxPowerBase; // TODO check type
 	int16_t   rxPowerBaseHigh = rxPowerBaseLow+1; // TODO check type
-	if(rxPowerBaseLow < 0) {
+	if(rxPowerBaseLow <= 0) {
 		rxPowerBaseLow  = 0;
 		rxPowerBaseHigh = 0;
-	} else if(rxPowerBaseHigh > 17) {
+	} else if(rxPowerBaseHigh >= 17) {
 		rxPowerBaseLow  = 17;
 		rxPowerBaseHigh = 17;
 	}
@@ -1381,7 +1381,7 @@ void DW1000Class::correctTimestamp(DW1000Time& timestamp) {
 	DW1000Time adjustmentTime;
 	adjustmentTime.setTimestamp((int16_t)(rangeBias*DW1000Time::DISTANCE_OF_RADIO_INV*0.001f));
 	// apply correction
-	timestamp += adjustmentTime;
+	timestamp -= adjustmentTime;
 }
 
 void DW1000Class::getSystemTimestamp(DW1000Time& time) {
@@ -1503,7 +1503,7 @@ float DW1000Class::getFirstPathPower() {
 	f3 = (uint16_t)fpAmpl3Bytes[0] | ((uint16_t)fpAmpl3Bytes[1] << 8);
 	N  = (((uint16_t)rxFrameInfo[2] >> 4) & 0xFF) | ((uint16_t)rxFrameInfo[3] << 4);
 	if(_pulseFrequency == TX_PULSE_FREQ_16MHZ) {
-		A       = 115.72;
+		A       = 113.77;
 		corrFac = 2.3334;
 	} else {
 		A       = 121.74;
@@ -1530,7 +1530,7 @@ float DW1000Class::getReceivePower() {
 	C = (uint16_t)cirPwrBytes[0] | ((uint16_t)cirPwrBytes[1] << 8);
 	N = (((uint16_t)rxFrameInfo[2] >> 4) & 0xFF) | ((uint16_t)rxFrameInfo[3] << 4);
 	if(_pulseFrequency == TX_PULSE_FREQ_16MHZ) {
-		A       = 115.72;
+		A       = 113.77;
 		corrFac = 2.3334;
 	} else {
 		A       = 121.74;


### PR DESCRIPTION
The change in rxPowerBaseLow and rxPowerBaseHigh is due to the fact that the old usage of "<" and ">" operators caused inconsistent behavior after the conversion from float to int. Imagine the situation where rxPowerBase is equal to -0.6. Conversion to int will cause rxPowerBaseLow to have value 0, and rxPowerBaseHigh will subsequently have a value of 1. The if(rxPowerBaseLow < 0) will not get triggered and the values remain as they are. After the conversion it therefore seems like rxPowerBase should lie somewhere in between the value 0 and 1, whereas its actual value is -0.6. This is clearly not as intended. Solved by changing the if statement to if(rxPowerBaseLow <= 0). Same applies for the case where rxPowerBase is higher than 17.

The timestamp correction has been changed to timestamp -= adjustmentTime; 
This is consistent with the fact that on page 12 of application note APS-011 by Decawave:
"Actual distance = Reported distance - Range Bias Correction"
Since the bias tables are directly copied from the same application note without inverting the sign in the biases, the sign in the timestamp correction should also be negative.
Tests I performed with both positive and negative bias correction also clearly show that the negative correction gives far superior performance. See figure below which demonstrates that the positive correction fails to correct the range dependent bias, whereas the negative correction succesfully does so.
![error_barplot_pluscorrect_mincorrect](https://user-images.githubusercontent.com/9050949/29324614-0cf7c34c-81e5-11e7-8ce8-b6ca8f0ec670.png)

Final changes made are the the "A" parameter used in the power calculations. This value corresponds with the value mentioned in section 4.7.2  in the DW1000 user manual.
