### PR TITLE
Implementation of the APS014 - DW1000 Antenna Delay Calibration

### DIFF
--- a/examples/Calibration_ANCHOR/Calibration_ANCHOR.ino
+++ b/examples/Calibration_ANCHOR/Calibration_ANCHOR.ino
@@ -1,0 +1,33 @@
+#include <SPI.h>
+#include <DW1000Ranging.h>
+
+const uint8_t PIN_RST = 9; // reset pin
+const uint8_t PIN_IRQ = 3; // irq pin
+const uint8_t PIN_SS = SS; // spi select pin
+const uint16_t ANTENNA_DELAY = 0;
+const char ADDRESS[] = "B2:00:00:00:B1:6B:00:B5";
+
+void setup() {
+  Serial.begin(115200);
+  
+  //init the configuration
+  DW1000Ranging.initCommunication(PIN_RST, PIN_SS, PIN_IRQ);
+
+  // General configuration
+  DW1000.setAntennaDelay(ANTENNA_DELAY);
+
+  // LED configuration
+  DW1000.enableDebounceClock();
+  DW1000.enableLedBlinking();
+  DW1000.setGPIOMode(MSGP0, LED_MODE); // enable GPIO0/RXOKLED blinking
+  DW1000.setGPIOMode(MSGP1, LED_MODE); // enable GPIO1/SFDLED blinking
+  DW1000.setGPIOMode(MSGP2, LED_MODE); // enable GPIO2/RXLED blinking
+  DW1000.setGPIOMode(MSGP3, LED_MODE); // enable GPIO3/TXLED blinking
+  
+  //we start the module as an anchor
+  DW1000Ranging.startAsAnchor(ADDRESS, DW1000.MODE_LONGDATA_RANGE_ACCURACY, false);
+}
+
+void loop() {
+  DW1000Ranging.loop();
+}

--- a/examples/Calibration_TAG/Calibration_TAG.ino
+++ b/examples/Calibration_TAG/Calibration_TAG.ino
@@ -1,0 +1,73 @@
+#include <SPI.h>
+#include <DW1000Ranging.h>
+#include <ArduinoJson.h>
+
+enum class Events : byte { NEW_RANGE = 0, NEW_DEVICE = 1, INACTIVE_DEVICE = 2, };
+
+const uint8_t PIN_RST = 9; // reset pin
+const uint8_t PIN_IRQ = 3; // irq pin
+const uint8_t PIN_SS = SS; // spi select pin
+const uint16_t ANTENNA_DELAY = 0;
+const char ADDRESS[] = "B1:00:00:00:B1:6B:00:B5";
+
+void setup() {
+  Serial.begin(115200);
+
+  //init the configuration
+  DW1000Ranging.initCommunication(PIN_RST, PIN_SS, PIN_IRQ);
+  DW1000Ranging.attachNewRange(newRange);
+  DW1000Ranging.attachNewDevice(newDevice);
+  DW1000Ranging.attachInactiveDevice(inactiveDevice);
+
+  // General configuration
+  DW1000.setAntennaDelay(ANTENNA_DELAY);
+
+  // LED configuration
+  DW1000.enableDebounceClock();
+  DW1000.enableLedBlinking();
+  DW1000.setGPIOMode(MSGP0, LED_MODE); // enable GPIO0/RXOKLED blinking
+  DW1000.setGPIOMode(MSGP1, LED_MODE); // enable GPIO1/SFDLED blinking
+  DW1000.setGPIOMode(MSGP2, LED_MODE); // enable GPIO2/RXLED blinking
+  DW1000.setGPIOMode(MSGP3, LED_MODE); // enable GPIO3/TXLED blinking
+  
+  //we start the module as a tag
+  DW1000Ranging.startAsTag(ADDRESS, DW1000.MODE_LONGDATA_RANGE_ACCURACY, false);
+}
+
+void loop() {
+  DW1000Ranging.loop();
+}
+
+void newRange() {
+  transmitDATA(Events::NEW_RANGE, DW1000Ranging.getDistantDevice());
+}
+
+void newDevice(DW1000Device* device) {
+  transmitDATA(Events::NEW_DEVICE, device);
+}
+
+void inactiveDevice(DW1000Device* device) {
+  transmitDATA(Events::INACTIVE_DEVICE, device);
+}
+
+void transmitDATA(const Events event, const DW1000Device* device) {
+  StaticJsonBuffer<200> jsonBuffer;
+  JsonObject& root = jsonBuffer.createObject();
+
+  const byte* shortAddress = DW1000Ranging.getCurrentShortAddress();
+  float temp, vbat;
+  DW1000.getTempAndVbat(temp, vbat);
+
+  root["type"] = static_cast<byte>(event);
+  root["ta"] = shortAddress[1]*256+shortAddress[0];
+  root["aa"] = device->getShortAddress();
+  root["r"] = (event==Events::NEW_RANGE) ? device->getRange() : 0.0f;
+  root["rxp"] = (event==Events::NEW_RANGE) ? device->getRXPower() : 0.0f;
+  root["fpp"] = (event==Events::NEW_RANGE) ? device->getFPPower() : 0.0f;
+  root["q"] = (event==Events::NEW_RANGE) ? device->getQuality() : 0.0f;
+  root["t"] = temp;
+  root["v"] = vbat;
+
+  root.printTo(Serial);
+  Serial.println();
+}

--- a/examples/Calibration_TAG/antenna_delay_calibration.py
+++ b/examples/Calibration_TAG/antenna_delay_calibration.py
@@ -1,0 +1,174 @@
+"""
+    Implementation of the APS014 - DW1000 Antenna Delay Calibration.
+"""
+#!/usr/bin/env python3
+
+
+import random
+import operator
+import numpy as np
+
+
+SPEED_OF_LIGHT = 299792458                       # [m/s]
+UNIT_OF_LOW_ORDER_BIT = 1/(128*499.2*10**6)      # [s]
+
+INITAL_DELAY = 513*10**-9                        # [s]
+INITAL_RANGE = 6*10**-9                          # [s]
+INITAL_QUALITY = 0
+pertubation_limit = 0.2*10**-9                   # [s]
+
+ITERATIONS = 100
+CANDIDATE_COUNT = 1000
+
+# All EDM_Actual ranges should be the same. (Ground Truth)
+EDM_ACTUAL = np.array([
+    [0, 2.0, 2.0],
+    [2.0, 0, 2.0],
+    [2.0, 2.0, 0]])
+
+# Use TWR to measure the EDM_Measured with all antenna delays set to zero.
+# This will require nChips*(nChips-1) measurements. Ideally each measurement should be
+# an average of several range estimates, we use 200 range estimates for each measurement.
+EDM_MEASUREMENT = np.array([
+    [0, 156.310368098160, 156.399548133595],
+    [156.359591002045, 0, 156.401709233791],
+    [156.366707566462, 156.503889980354, 0]])
+
+# Convert measured EDM_Measured and EDM_Actual to times (ToF_measured and ToF_actual)
+TOF_ACTUAL = EDM_ACTUAL / SPEED_OF_LIGHT
+TOF_MEASUREMENT = EDM_MEASUREMENT / SPEED_OF_LIGHT
+
+
+def main():
+    """ Main function """
+    candidate_set = []
+
+    for i in range(0, ITERATIONS):
+        populate(candidate_set, i)
+        evaluate(candidate_set)
+
+        print(
+            "Iter: {0:03d}, Norm: {1:2.6e}, Delays: {2:2.6e} {3:2.6e} {4:2.6e} {5:2.6e} {6:2.6e} {7:2.6e}".format(
+                i+1,
+                candidate_set[0][0],
+                candidate_set[0][1], candidate_set[0][2], candidate_set[0][3],
+                candidate_set[0][4], candidate_set[0][5], candidate_set[0][6]))
+
+    # Print Best Candidate
+    # The units of the low order bit are approximately 15.65 picoseconds.
+    # The actual unit may be calculated as 1 / (128*499.2*10^6) seconds.
+    print(
+        "Antenna Delay: 1={0:05d} 2={1:05d} 3={2:05d} 4={3:05d} 5={4:05d} 6={5:05d}".format(
+            round(candidate_set[0][1]/(2*UNIT_OF_LOW_ORDER_BIT)),
+            round(candidate_set[0][2]/(2*UNIT_OF_LOW_ORDER_BIT)),
+            round(candidate_set[0][3]/(2*UNIT_OF_LOW_ORDER_BIT)),
+            round(candidate_set[0][4]/(2*UNIT_OF_LOW_ORDER_BIT)),
+            round(candidate_set[0][5]/(2*UNIT_OF_LOW_ORDER_BIT)),
+            round(candidate_set[0][6]/(2*UNIT_OF_LOW_ORDER_BIT))))
+
+
+def populate(candidate_set, iteration):
+    """ Populate the set of candidate delay estimates """
+    global pertubation_limit
+
+    # First iteration?
+    if not candidate_set:
+        # Generate a set of random delays uniformly distributed round initial delay ±6ns.
+        a = INITAL_DELAY-INITAL_RANGE
+        b = INITAL_DELAY+INITAL_RANGE
+
+        for i in range(0, CANDIDATE_COUNT):
+            candidate_set.append((
+                INITAL_QUALITY,
+                random.uniform(a, b),
+                random.uniform(a, b),
+                random.uniform(a, b),
+                random.uniform(a, b),
+                random.uniform(a, b),
+                random.uniform(a, b)))
+    else:
+        # Select the best 25% of the set and include them in the new set.
+        best25_count = round(len(candidate_set) * 0.25)
+        best25 = candidate_set[0:best25_count]
+        candidate_set.clear()
+        for candidate in best25:
+            candidate_set.append((
+                INITAL_QUALITY,
+                candidate[1], candidate[2], candidate[3],
+                candidate[4], candidate[5], candidate[6]))
+
+        # Perform 3 times
+        for i in range(0, 3):
+            # Randomly perturb the initial 25% within the perturbation limits
+            # and add them to the set.
+            for candidate in best25:
+                candidate_set.append((
+                    INITAL_QUALITY,
+                    random.uniform(candidate[1]-pertubation_limit, candidate[1]+pertubation_limit),
+                    random.uniform(candidate[2]-pertubation_limit, candidate[2]+pertubation_limit),
+                    random.uniform(candidate[3]-pertubation_limit, candidate[3]+pertubation_limit),
+                    random.uniform(candidate[4]-pertubation_limit, candidate[4]+pertubation_limit),
+                    random.uniform(candidate[5]-pertubation_limit, candidate[5]+pertubation_limit),
+                    random.uniform(candidate[6]-pertubation_limit, candidate[6]+pertubation_limit)))
+
+    # Every 20 iterations halve the perturbation limits
+    if iteration != 0 and iteration % 20 == 0:
+        pertubation_limit = pertubation_limit / 2
+
+
+def evaluate(candidate_set):
+    """ Evaluate the quality of the candidates """
+
+    # Foreach candidate
+    for i in range(0, len(candidate_set)):
+        candidate = candidate_set[i]
+
+        delay_chip1 = np.zeros((3, 3))
+        delay_chip2 = np.zeros((3, 3))
+
+        create_chip_delay(candidate, delay_chip1, delay_chip2)
+
+        # Compute the time of flight matrix given the candidate delays.
+        tof_candidate = 0.5 * delay_chip1 + 0.5 * delay_chip2 + TOF_MEASUREMENT
+
+        # Compute the (euclidean) norm of the difference between the
+        # tof_acutal matrix and the tof_candidate matrix.
+        quality = np.linalg.norm(TOF_ACTUAL - tof_candidate)
+
+        candidate_set[i] = (
+            quality,
+            candidate[1], candidate[2], candidate[3],
+            candidate[4], candidate[5], candidate[6])
+
+    # Sort the candidates. Lowest error first.
+    candidate_set.sort(key=operator.itemgetter(0), reverse=False)
+
+#
+# Are the delay_chip matrix are correct?
+#
+def create_chip_delay(candidate, delay_chip1, delay_chip2):
+    """ Creates the chip delay matrix """
+
+    delay_chip1[0, 1] = delay_chip1[0, 2] = candidate[1]
+    delay_chip1[1, 0] = delay_chip1[1, 2] = candidate[2]
+    delay_chip1[2, 0] = delay_chip1[2, 1] = candidate[3]
+
+    delay_chip2[1, 0] = delay_chip2[2, 0] = candidate[4]
+    delay_chip2[0, 1] = delay_chip2[2, 1] = candidate[5]
+    delay_chip2[0, 2] = delay_chip2[1, 2] = candidate[6]
+
+'''
+def create_chip_delay(candidate, delay_chip1, delay_chip2):
+    """ Creates the chip delay matrix """
+
+    delay_chip1[0, 1] = delay_chip1[0, 2] = candidate[1]
+    delay_chip1[1, 0] = delay_chip1[1, 2] = candidate[2]
+    delay_chip1[2, 0] = delay_chip1[2, 1] = candidate[3]
+
+    delay_chip2[1, 0] = delay_chip2[2, 0] = candidate[1]
+    delay_chip2[0, 1] = delay_chip2[2, 1] = candidate[2]
+    delay_chip2[0, 2] = delay_chip2[1, 2] = candidate[3]
+'''
+
+if __name__ == '__main__':
+    main()

--- a/examples/Calibration_TAG/serial_to_json_to_csv.py
+++ b/examples/Calibration_TAG/serial_to_json_to_csv.py
@@ -1,0 +1,40 @@
+"""
+    Reads the json data from the DWM1000 Controller Board and write it to a csv file.
+"""
+#!/usr/bin/env python3
+
+
+import json
+import csv
+import serial
+
+
+SERIAL_PORT = "/dev/ttyUSB0"
+CSV_FILE_NAME = "B1.csv"
+GROUND_TRUTH = 2.0
+MEASUREMENTS = 1000
+
+
+with serial.Serial(SERIAL_PORT, 115200, timeout=2) as ser:
+    with open(CSV_FILE_NAME, "a") as csv_file:
+        csv_writer = csv.writer(csv_file, delimiter=';', lineterminator='\n')
+
+        for i in range(0, MEASUREMENTS):
+            print("{0:03d} of {1:03d}".format(i+1, MEASUREMENTS))
+            while True:
+                line = ser.readline()
+                line = line.decode("utf-8")
+                try:
+                    print(line)
+                    obj = json.loads(line)
+                except ValueError:
+                    continue
+                break
+
+            # CSV Columns:
+            # type; tag_address; anchor_address; ground_truth; range;
+            # receive_power; first_path_power; receive_quality;
+            # temperature; voltage
+            csv_writer.writerow([
+                obj["type"], obj["ta"], obj["aa"], GROUND_TRUTH, obj["r"],
+                obj["rxp"], obj["fpp"], obj["q"], obj["t"], obj["v"]])

--- a/src/DW1000.cpp
+++ b/src/DW1000.cpp
@@ -1080,9 +1080,8 @@ void DW1000Class::commitConfiguration() {
 	tune();
 	// TODO clean up code + antenna delay/calibration API
 	// TODO setter + check not larger two bytes integer
-	byte antennaDelayBytes[LEN_STAMP];
-	writeValueToBytes(antennaDelayBytes, 16384, LEN_STAMP);
-	_antennaDelay.setTimestamp(antennaDelayBytes);
+	byte antennaDelayBytes[DW1000Time::LENGTH_TIMESTAMP];
+	_antennaDelay.getTimestamp(antennaDelayBytes);
 	writeBytes(TX_ANTD, NO_SUB, antennaDelayBytes, LEN_TX_ANTD);
 	writeBytes(LDE_IF, LDE_RXANTD_SUB, antennaDelayBytes, LEN_LDE_RXANTD);
 }
@@ -1544,6 +1543,16 @@ float DW1000Class::getReceivePower() {
 		estRxPwr += (estRxPwr+88)*corrFac;
 	}
 	return estRxPwr;
+}
+
+void DW1000Class::setAntennaDelay(const uint16_t value) {
+	_antennaDelay.setTimestamp(value);
+}
+
+uint16_t DW1000Class::getAntennaDelay() {
+	uint16_t antennaDelay;
+	antennaDelay = static_cast<uint16_t>(_antennaDelay.getTimestamp());
+	return antennaDelay;
 }
 
 /* ###########################################################################

--- a/src/DW1000.h
+++ b/src/DW1000.h
@@ -259,6 +259,10 @@ public:
 	static float getReceivePower();
 	static float getFirstPathPower();
 	static float getReceiveQuality();
+
+	/* antenna delay configguration */
+	static void setAntennaDelay(const uint16_t value);
+	static uint16_t getAntennaDelay();
 	
 	/* interrupt management. */
 	static void interruptOnSent(boolean val);


### PR DESCRIPTION
Hi,

I am currently trying to calibrate the antenna delay of my DW1000 Controller Boards. But I have some trouble with the formula in "Figure 5: Evaluate the quality of the candidates - flowchart". Maybe I have done everything correct and you can integrate my changes or maybe someone can help me with that point.

DW1000.h/DW1000.cpp:
- I have inserted two static function so that you can set/get the antenna delay from the ino files.

Calibration_ANCHOR.ino:
- Note: My board uses another PIN_IRQ!
- The same like DW1000Ranging_ANCHOR.ino but with the call to setAntennaDelay.

Calibration_TAG.ino:
- Note: My board uses another PIN_IRQ!
- The same like DW1000Ranging_TAG.ino but with the call to setAntennaDelay and transfer of the relevant calibration data in json format to the host computer.

serial_to_json_to_csv.py:
- Runs on the host computer, catches the json data and write it to a csv file on the host computer.
- You have to run the script for each DW1000-based device, see also "Figure 2: TWR reference device generation setup".
- Change once the parameter SERIAL_PORT and GROUND_TRUTH.
- Change for each DW1000-based device the output file (CSV_FILE_NAME) in the script.
- Use a spreadsheet program to compute the average of several range estimates, you need these values in the next script. (Here is the spreadsheet file with my measurements: [measurement_two_meter.xlsx](https://github.com/thotro/arduino-dw1000/files/1500156/measurement_two_meter.xlsx))

antenna_delay_calibration.py:
- Implementation of the APS014 - DW1000 Antenna Delay Calibration
- Populate EDM_ACTUAL and EDM_MEASUREMENT, run it and you get the antenna delay values for each DW1000-based device.
- **Note: I have no idea if the create_chip_delay function is correct, the "Figure 5: Evaluate the quality of the candidates - flowchart" is in this point not precise enough.**

With friendly greetings from Germany.