### PR TITLE
Fix value of FS_PLLTUNE for channel 3 in DW1000Class::tune

### DIFF
--- a/src/DW1000.cpp
+++ b/src/DW1000.cpp
@@ -504,7 +504,7 @@ void DW1000Class::tune() {
 		writeValueToBytes(fsplltune, 0x26, LEN_FS_PLLTUNE);
 	} else if(_channel == CHANNEL_3) {
 		writeValueToBytes(fspllcfg, 0x08401009L, LEN_FS_PLLCFG);
-		writeValueToBytes(fsplltune, 0x5E, LEN_FS_PLLTUNE);
+		writeValueToBytes(fsplltune, 0x56, LEN_FS_PLLTUNE);
 	} else if(_channel == CHANNEL_5 || _channel == CHANNEL_7) {
 		writeValueToBytes(fspllcfg, 0x0800041DL, LEN_FS_PLLCFG);
 		writeValueToBytes(fsplltune, 0xBE, LEN_FS_PLLTUNE);


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc update?   | no <!-- Doc = documentation -->
| BC breaks?    | no <!-- BC = backwards compatibility -->
| Deprecations? | no
| Fixed tickets | #268  <!-- #-prefixed issue number(s), if any -->

Fixes #268, simple value change for FS_PLLTUNE as recommended by the official manual v2.12.
