### PR TITLE
fix crash when searchDistantDevice returns NULL

### DIFF
--- a/src/DW1000Ranging.cpp
+++ b/src/DW1000Ranging.cpp
@@ -316,7 +316,7 @@ DW1000Device* DW1000RangingClass::searchDistantDevice(byte shortAddress[]) {
 		}
 	}
 	
-	return NULL;
+	return nullptr;
 }
 
 DW1000Device* DW1000RangingClass::getDistantDevice() {
@@ -496,7 +496,7 @@ void DW1000RangingClass::loop() {
 			DW1000Device* myDistantDevice = searchDistantDevice(address);
 			
 			
-			if((_networkDevicesNumber == 0) || (myDistantDevice == NULL)) {
+			if((_networkDevicesNumber == 0) || (myDistantDevice == nullptr)) {
 				//we don't have the short address of the device in memory
 				if (DEBUG) {
 					Serial.println("Not found");
@@ -641,7 +641,7 @@ void DW1000RangingClass::loop() {
 					if(myDistantDevice->getIndex() == _networkDevicesNumber-1) {
 						_expectedMsgId = RANGE_REPORT;
 						//and transmit the next message (range) of the ranging protocole (in broadcast)
-						transmitRange(NULL);
+						transmitRange(nullptr);
 					}
 				}
 				else if(messageType == RANGE_REPORT) {
@@ -729,7 +729,7 @@ void DW1000RangingClass::timerTick() {
 		if(_type == TAG) {
 			_expectedMsgId = POLL_ACK;
 			//send a prodcast poll
-			transmitPoll(NULL);
+			transmitPoll(nullptr);
 		}
 	}
 	else if(counterForBlink == 0) {
@@ -795,7 +795,7 @@ void DW1000RangingClass::transmitPoll(DW1000Device* myDistantDevice) {
 	
 	transmitInit();
 	
-	if(myDistantDevice == NULL) {
+	if(myDistantDevice == nullptr) {
 		//we need to set our timerDelay:
 		_timerDelay = DEFAULT_TIMER_DELAY+(uint16_t)(_networkDevicesNumber*3*DEFAULT_REPLY_DELAY_TIME/1000);
 		
@@ -853,7 +853,7 @@ void DW1000RangingClass::transmitRange(DW1000Device* myDistantDevice) {
 	transmitInit();
 	
 	
-	if(myDistantDevice == NULL) {
+	if(myDistantDevice == nullptr) {
 		//we need to set our timerDelay:
 		_timerDelay = DEFAULT_TIMER_DELAY+(uint16_t)(_networkDevicesNumber*3*DEFAULT_REPLY_DELAY_TIME/1000);
 		

--- a/src/DW1000Ranging.cpp
+++ b/src/DW1000Ranging.cpp
@@ -393,7 +393,9 @@ void DW1000RangingClass::loop() {
 			if(messageType == POLL_ACK) {
 				DW1000Device* myDistantDevice = searchDistantDevice(_lastSentToShortAddress);
 				
-				DW1000.getTransmitTimestamp(myDistantDevice->timePollAckSent);
+				if (myDistantDevice) {
+					DW1000.getTransmitTimestamp(myDistantDevice->timePollAckSent);
+				}
 			}
 		}
 		else if(_type == TAG) {
@@ -411,7 +413,9 @@ void DW1000RangingClass::loop() {
 					//we search the device associated with the last send address
 					DW1000Device* myDistantDevice = searchDistantDevice(_lastSentToShortAddress);
 					//we save the value just for one device
-					myDistantDevice->timePollSent = timePollSent;
+					if (myDistantDevice) {
+						myDistantDevice->timePollSent = timePollSent;
+					}
 				}
 			}
 			else if(messageType == RANGE) {
@@ -428,7 +432,9 @@ void DW1000RangingClass::loop() {
 					//we search the device associated with the last send address
 					DW1000Device* myDistantDevice = searchDistantDevice(_lastSentToShortAddress);
 					//we save the value just for one device
-					myDistantDevice->timeRangeSent = timeRangeSent;
+					if (myDistantDevice) {
+						myDistantDevice->timeRangeSent = timeRangeSent;
+					}
 				}
 				
 			}
@@ -490,15 +496,17 @@ void DW1000RangingClass::loop() {
 			DW1000Device* myDistantDevice = searchDistantDevice(address);
 			
 			
-			if((_networkDevicesNumber != 0) && (myDistantDevice == NULL)) {
-				Serial.println("Not found");
+			if((_networkDevicesNumber == 0) || (myDistantDevice == NULL)) {
 				//we don't have the short address of the device in memory
-				/*
-				Serial.print("unknown: ");
-				Serial.print(address[0], HEX);
-				Serial.print(":");
-				Serial.println(address[1], HEX);
-				*/
+				if (DEBUG) {
+					Serial.println("Not found");
+					/*
+					Serial.print("unknown: ");
+					Serial.print(address[0], HEX);
+					Serial.print(":");
+					Serial.println(address[1], HEX);
+					*/
+				}
 				return;
 			}
 			


### PR DESCRIPTION
This can occur when the tag and the anchor are at the edge of the connection range as describe in issue #270.
This bug fix is actually an update of #236, but with one extra check missing and the error message only printed in debug mode.

The configuration have been tested and shows that:
- before the fix, the anchor was doing a hard fault due to the NULL pointer
- after the fix, the ranging is properly working
