### PR TITLE
Implemented antenna calibration API with backwards compatibility

### DIFF
--- a/src/DW1000.cpp
+++ b/src/DW1000.cpp
@@ -61,6 +61,7 @@ byte       DW1000Class::_preambleLength      = TX_PREAMBLE_LEN_128;
 byte       DW1000Class::_preambleCode        = PREAMBLE_CODE_16MHZ_4;
 byte       DW1000Class::_channel             = CHANNEL_5;
 DW1000Time DW1000Class::_antennaDelay;
+boolean	   DW1000Class::_antennaCalibrated	 = false;
 boolean    DW1000Class::_smartPower          = false;
 
 boolean    DW1000Class::_frameCheck          = true;
@@ -1017,6 +1018,7 @@ void DW1000Class::interruptOnAutomaticAcknowledgeTrigger(boolean val) {
 
 void DW1000Class::setAntennaDelay(const uint16_t value) {
 	_antennaDelay.setTimestamp(value);
+	_antennaCalibrated = true;
 }
 
 uint16_t DW1000Class::getAntennaDelay() {
@@ -1088,8 +1090,12 @@ void DW1000Class::commitConfiguration() {
 	tune();
 	// TODO check not larger two bytes integer
 	byte antennaDelayBytes[DW1000Time::LENGTH_TIMESTAMP];
-	if( _antennaDelay.getTimestamp() == 0) { _antennaDelay.setTimestamp(16384); } // Compatibility with old versions.
+	if( _antennaDelay.getTimestamp() == 0 && _antennaCalibrated == false) {
+		_antennaDelay.setTimestamp(16384);
+		_antennaCalibrated = true;
+	} // Compatibility with old versions.
 	_antennaDelay.getTimestamp(antennaDelayBytes);
+
 	writeBytes(TX_ANTD, NO_SUB, antennaDelayBytes, LEN_TX_ANTD);
 	writeBytes(LDE_IF, LDE_RXANTD_SUB, antennaDelayBytes, LEN_LDE_RXANTD);
 }

--- a/src/DW1000.h
+++ b/src/DW1000.h
@@ -455,6 +455,7 @@ public:
 	static byte       _dataRate;
 	static byte       _pacSize;
 	static DW1000Time _antennaDelay;
+	static boolean    _antennaCalibrated;
 	
 	/* internal helper to remember how to properly act. */
 	static boolean _permanentReceive;


### PR DESCRIPTION
<!-- BEGIN - This is a comment just for you visible

Please use the following template to give us as mutch information as you can.
Not used rows can be deleted.

END - This is a comment just for you visible -->

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Doc update?   | no <!-- Doc = documentation -->
| BC breaks?    | no <!-- BC = backwards compatibility -->
| Deprecations? | no
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->

This is a simple improvement based on pull request #244 but doesn't break backwards compatibility.
