### PR TITLE
Moved default channel setting inside setDefaults

### DIFF
--- a/src/DW1000.cpp
+++ b/src/DW1000.cpp
@@ -334,14 +334,6 @@ void DW1000Class::enableMode(const byte mode[]) {
 	setDataRate(mode[0]);
 	setPulseFrequency(mode[1]);
 	setPreambleLength(mode[2]);
-	// TODO add channel and code to mode tuples
-	// TODO add channel and code settings with checks (see Table 58)
-	setChannel(CHANNEL_5);
-	if(mode[1] == TX_PULSE_FREQ_16MHZ) {
-		setPreambleCode(PREAMBLE_CODE_16MHZ_4);
-	} else {
-		setPreambleCode(PREAMBLE_CODE_64MHZ_10);
-	}
 }
 
 void DW1000Class::tune() {
@@ -1245,6 +1237,15 @@ void DW1000Class::setDefaults() {
 		// default mode when powering up the chip
 		// still explicitly selected for later tuning
 		enableMode(MODE_LONGDATA_RANGE_LOWPOWER);
+		
+		// TODO add channel and code to mode tuples
+	    // TODO add channel and code settings with checks (see DW1000 user manual 10.5 table 61)/
+	    setChannel(CHANNEL_5);
+		if(getPulseFrequency() == TX_PULSE_FREQ_16MHZ) {
+			setPreambleCode(PREAMBLE_CODE_16MHZ_4);
+		} else {
+			setPreambleCode(PREAMBLE_CODE_64MHZ_10);
+		}
 	}
 }
 


### PR DESCRIPTION
Co-authored-by: Sonic0 <andrea.salvatori92@gmail.com>

<!-- BEGIN - This is a comment just for you visible

Please use the following template to give us as mutch information as you can.
Not used rows can be deleted.

END - This is a comment just for you visible -->

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc update?   | no <!-- Doc = documentation -->
| BC breaks?    | yes , enableMode doesn't set channel 5 by default <!-- BC = backwards compatibility -->
| Deprecations? | no
| Fixed tickets | #<!-- #-prefixed issue number(s), if any -->

Enable mode shouldn't set channel 5 as a default, rather this should be left to the setDefaults() function.
Fix: using enableMode used to reset channel to 5.