### PR TITLE
Fixed sfd sequence configuration for 110Kbps

### DIFF
--- a/src/DW1000.cpp
+++ b/src/DW1000.cpp
@@ -1139,10 +1139,14 @@ void DW1000Class::setDataRate(byte rate) {
 		setBit(_chanctrl, LEN_CHAN_CTRL, DWSFD_BIT, false);
 		setBit(_chanctrl, LEN_CHAN_CTRL, TNSSFD_BIT, false);
 		setBit(_chanctrl, LEN_CHAN_CTRL, RNSSFD_BIT, false);
-	} else {
+	} else if (rate == TRX_RATE_850KBPS) {
 		setBit(_chanctrl, LEN_CHAN_CTRL, DWSFD_BIT, true);
 		setBit(_chanctrl, LEN_CHAN_CTRL, TNSSFD_BIT, true);
 		setBit(_chanctrl, LEN_CHAN_CTRL, RNSSFD_BIT, true);
+	} else {
+		setBit(_chanctrl, LEN_CHAN_CTRL, DWSFD_BIT, true);
+		setBit(_chanctrl, LEN_CHAN_CTRL, TNSSFD_BIT, false);
+		setBit(_chanctrl, LEN_CHAN_CTRL, RNSSFD_BIT, false);
 	}
 	byte sfdLength;
 	if(rate == TRX_RATE_6800KBPS) {


### PR DESCRIPTION
Co-authored-by: Sonic0 <andrea.salvatori92@gmail.com>

<!-- BEGIN - This is a comment just for you visible

Please use the following template to give us as mutch information as you can.
Not used rows can be deleted.

END - This is a comment just for you visible -->

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc update?   | no <!-- Doc = documentation -->
| BC breaks?    | no <!-- BC = backwards compatibility -->
| Deprecations? | no
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->

Fixed a bug that set the wrong bits when configuring sfd configuration
(For reference see Table 21 of the latest DW1000 user manual, from the register 0x21 at chapter 7.2.34)