### PR TITLE
Fix Incorrect Values of Temp & VBat

### DIFF
--- a/src/DW1000.cpp
+++ b/src/DW1000.cpp
@@ -917,8 +917,8 @@ void DW1000Class::getTempAndVbat(float& temp, float& vbat) {
 	byte sar_ltemp = 0; readBytes(TX_CAL, 0x04, &sar_ltemp, 1);
 	
 	// calculate voltage and temperature
-	vbat = (sar_lvbat - _vmeas3v3) / 173.0f + 3.3f;
-	temp = (sar_ltemp - _tmeas23C) * 1.14f + 23.0f;
+	vbat = ((float)sar_lvbat - (float)_vmeas3v3) / 173.0f + 3.3f;
+	temp = ((float)sar_ltemp - (float)_tmeas23C) * 1.14f + 23.0f;
 }
 
 void DW1000Class::setEUI(char eui[]) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc update?   | no <!-- Doc = documentation -->
| BC breaks?    | yes <!-- BC = backwards compatibility -->
| Deprecations? | no
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->

If not cast to float first the computed values become irregular,
like (temp, vbat) = (-108.099991, 2.317341).
After this revision and validation by thermometer, the values are
reasonable (62.899998, 3.184393).