### PR TITLE
Added CHANNEL selection in DW1000 RANGING

### DIFF
--- a/examples/DW1000Ranging_ANCHOR/DW1000Ranging_ANCHOR.ino
+++ b/examples/DW1000Ranging_ANCHOR/DW1000Ranging_ANCHOR.ino
@@ -26,7 +26,7 @@ void setup() {
   //DW1000Ranging.useRangeFilter(true);
   
   //we start the module as an anchor
-  DW1000Ranging.startAsAnchor("82:17:5B:D5:A9:9A:E2:9C", DW1000.MODE_LONGDATA_RANGE_ACCURACY);
+  DW1000Ranging.startAsAnchor("82:17:5B:D5:A9:9A:E2:9C", DW1000.MODE_LONGDATA_RANGE_ACCURACY,DW1000.CHANNEL_5);
 }
 
 void loop() {

--- a/examples/DW1000Ranging_TAG/DW1000Ranging_TAG.ino
+++ b/examples/DW1000Ranging_TAG/DW1000Ranging_TAG.ino
@@ -26,7 +26,7 @@ void setup() {
   //DW1000Ranging.useRangeFilter(true);
   
   //we start the module as a tag
-  DW1000Ranging.startAsTag("7D:00:22:EA:82:60:3B:9C", DW1000.MODE_LONGDATA_RANGE_ACCURACY);
+  DW1000Ranging.startAsTag("7D:00:22:EA:82:60:3B:9C", DW1000.MODE_LONGDATA_RANGE_ACCURACY, DW1000.CHANNEL_5);
 }
 
 void loop() {

--- a/src/DW1000Ranging.cpp
+++ b/src/DW1000Ranging.cpp
@@ -105,13 +105,14 @@ void DW1000RangingClass::initCommunication(uint8_t myRST, uint8_t mySS, uint8_t 
 }
 
 
-void DW1000RangingClass::configureNetwork(uint16_t deviceAddress, uint16_t networkId, const byte mode[]) {
+void DW1000RangingClass::configureNetwork(uint16_t deviceAddress, uint16_t networkId, const byte mode[], const byte channel) {
 	// general configuration
 	DW1000.newConfiguration();
 	DW1000.setDefaults();
 	DW1000.setDeviceAddress(deviceAddress);
 	DW1000.setNetworkId(networkId);
 	DW1000.enableMode(mode);
+	DW1000.setChannel(channel);
 	DW1000.commitConfiguration();
 	
 }
@@ -159,7 +160,7 @@ void DW1000RangingClass::generalStart() {
 }
 
 
-void DW1000RangingClass::startAsAnchor(char address[], const byte mode[], const bool randomShortAddress) {
+void DW1000RangingClass::startAsAnchor(char address[], const byte mode[],const byte channel, const bool randomShortAddress) {
 	//save the address
 	DW1000.convertToByte(address, _currentAddress);
 	//write the address on the DW1000 chip
@@ -180,7 +181,7 @@ void DW1000RangingClass::startAsAnchor(char address[], const byte mode[], const 
 	
 	//we configur the network for mac filtering
 	//(device Address, network ID, frequency)
-	DW1000Ranging.configureNetwork(_currentShortAddress[0]*256+_currentShortAddress[1], 0xDECA, mode);
+	DW1000Ranging.configureNetwork(_currentShortAddress[0]*256+_currentShortAddress[1], 0xDECA, mode, channel);
 	
 	//general start:
 	generalStart();
@@ -192,7 +193,7 @@ void DW1000RangingClass::startAsAnchor(char address[], const byte mode[], const 
 	
 }
 
-void DW1000RangingClass::startAsTag(char address[], const byte mode[], const bool randomShortAddress) {
+void DW1000RangingClass::startAsTag(char address[], const byte mode[],const byte channel, const bool randomShortAddress) {
 	//save the address
 	DW1000.convertToByte(address, _currentAddress);
 	//write the address on the DW1000 chip
@@ -213,7 +214,7 @@ void DW1000RangingClass::startAsTag(char address[], const byte mode[], const boo
 	
 	//we configur the network for mac filtering
 	//(device Address, network ID, frequency)
-	DW1000Ranging.configureNetwork(_currentShortAddress[0]*256+_currentShortAddress[1], 0xDECA, mode);
+	DW1000Ranging.configureNetwork(_currentShortAddress[0]*256+_currentShortAddress[1], 0xDECA, mode, channel);
 	
 	generalStart();
 	//defined type as tag

--- a/src/DW1000Ranging.h
+++ b/src/DW1000Ranging.h
@@ -76,10 +76,10 @@ public:
 	
 	//initialisation
 	static void    initCommunication(uint8_t myRST = DEFAULT_RST_PIN, uint8_t mySS = DEFAULT_SPI_SS_PIN, uint8_t myIRQ = 2);
-	static void    configureNetwork(uint16_t deviceAddress, uint16_t networkId, const byte mode[]);
+	static void    configureNetwork(uint16_t deviceAddress, uint16_t networkId, const byte mode[], const byte channel=DW1000.CHANNEL_5);
 	static void    generalStart();
-	static void    startAsAnchor(char address[], const byte mode[], const bool randomShortAddress = true);
-	static void    startAsTag(char address[], const byte mode[], const bool randomShortAddress = true);
+	static void    startAsAnchor(char address[], const byte mode[],const byte channel=DW1000.CHANNEL_5, const bool randomShortAddress = true);
+	static void    startAsTag(char address[], const byte mode[],const byte channel=DW1000.CHANNEL_5, const bool randomShortAddress = true);
 	static boolean addNetworkDevices(DW1000Device* device, boolean shortAddress);
 	static boolean addNetworkDevices(DW1000Device* device);
 	static void    removeNetworkDevices(int16_t index);


### PR DESCRIPTION
| New feature?  | yes

Added channel changing for DWM1000Ranging ANCHOR/TAG.

Now it is possible to change channel for DW1000 Ranging Tag and Anchor.
`DW1000Ranging.startAsAnchor("82:17:5B:D5:A9:9A:E2:9C",DW1000.MODE_LONGDATA_RANGE_ACCURACY,DW1000.CHANNEL_5);`

`DW1000Ranging.startAsTag("7D:00:22:EA:82:60:3B:9C", DW1000.MODE_LONGDATA_RANGE_ACCURACY, DW1000.CHANNEL_5);`
`