### PR TITLE
Added Support for ESP32

### DIFF
--- a/src/DW1000.cpp
+++ b/src/DW1000.cpp
@@ -169,8 +169,8 @@ void DW1000Class::begin(uint8_t irq, uint8_t rst) {
     	pinMode(irq, INPUT);
 	// start SPI
 	SPI.begin();
-#ifndef ESP8266
-	SPI.usingInterrupt(digitalPinToInterrupt(irq)); // not every board support this, e.g. ESP8266
+#if !(defined(ESP8266) || defined(ESP32))
+	SPI.usingInterrupt(digitalPinToInterrupt(irq)); // not every board support this, e.g. ESP8266, ESP32
 #endif
 	// pin and basic member setup
 	_rst        = rst;

--- a/src/DW1000CompileOptions.h
+++ b/src/DW1000CompileOptions.h
@@ -24,10 +24,10 @@
 
 /**
  * Printable DW1000Time object costs about: rom: 490 byte ; ram: 58 byte
- * This option is needed because compiler can not optimize unused codes from inheritanced methods 
+ * This option is needed because compiler can not optimize unused codes from inherited methods 
  * Some examples or debug code use this
  * Set false if you do not need it and have to save some space
  */
-#define DW1000TIME_H_PRINTABLE true
+#define DW1000TIME_H_PRINTABLE false
 
 #endif // DW1000COMPILEOPTIONS_H

--- a/src/DW1000Ranging.cpp
+++ b/src/DW1000Ranging.cpp
@@ -521,7 +521,7 @@ void DW1000RangingClass::loop() {
 				if(messageType == POLL) {
 					//we receive a POLL which is a broacast message
 					//we need to grab info about it
-					int16_t numberDevices = 0;
+					uint16_t numberDevices = 0;
 					memcpy(&numberDevices, data+SHORT_MAC_LEN+1, 1);
 					
 					for(uint16_t i = 0; i < numberDevices; i++) {

--- a/src/DW1000Ranging.cpp
+++ b/src/DW1000Ranging.cpp
@@ -368,6 +368,7 @@ int16_t DW1000RangingClass::detectMessageType(byte datas[]) {
 		//we have a short mac frame message (poll, range, range report, etc..)
 		return datas[SHORT_MAC_LEN];
 	}
+	return INT16_MAX;
 }
 
 void DW1000RangingClass::loop() {

--- a/src/DW1000Time.cpp
+++ b/src/DW1000Time.cpp
@@ -279,7 +279,7 @@ boolean DW1000Time::operator!=(const DW1000Time& cmp) const {
 	return _timestamp != cmp.getTimestamp();
 }
 
-#ifdef DW1000TIME_H_PRINTABLE
+#if DW1000TIME_H_PRINTABLE
 /**
  * For debuging, print timestamp pretty as integer with arduinos serial
  * @deprecated use Serial.print(object)


### PR DESCRIPTION
SPI.usingInterrupt() is not available on ESP32 as well as ESP8266. Extended checking for the preprocesser marco to include the ESP32.

<!-- BEGIN - This is a comment just for you visible

Please use the following template to give us as much information as you can.
Not used rows can be deleted.

END - This is a comment just for you visible -->

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| Doc update?   | no <!-- Doc = documentation -->
| BC breaks?    | no <!-- BC = backwards compatibility -->
| Deprecations? | no
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
